### PR TITLE
README typo: add 'will' in the scalabality section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ following abilities.
 - **Scalability** - It always works with a single dispatcher per queue
   which can concurrently dispatch jobs to workers via HTTP.
   Scalability of workers themselves should be maintained by a load
-  balancer in the ordinary way.  This means that adding a worker never
-  harm performance of grabbing jobs from a queue.
+  balancer in the ordinary way.  This means that adding a worker will
+  never harm performance of grabbing jobs from a queue.
 
 - **Flexibility** - It supports the following features.
 


### PR DESCRIPTION
This little thing caught my eye, thought it was worth sharing with you fine folks here.

Alternative phrasing of this could be

> This means that adding a worker never harms performance of grabbing jobs from a queue.