### PR TITLE
Complete as permanent at retry limit

### DIFF
--- a/jobqueue/jobqueue.go
+++ b/jobqueue/jobqueue.go
@@ -92,7 +92,7 @@ func (q *jobQueue) Pop(limit uint) ([]Job, error) {
 
 func (q *jobQueue) Complete(job Job, res *Result) {
 	var j *completedJob
-	if res.Status == ResultStatusSuccess {
+	if res.IsSuccess() {
 		j = &completedJob{job, 0}
 	} else {
 		j = &completedJob{job, 1}
@@ -101,12 +101,12 @@ func (q *jobQueue) Complete(job Job, res *Result) {
 	loggable := j.ToLoggable()
 	logger.Info(q.name, "complete", loggable, res.Message)
 
-	if res.Status == ResultStatusSuccess {
+	if res.IsSuccess() {
 		q.stats.succeed(1)
 		q.stats.complete(1)
 		q.stats.elapsed(logger.Elapsed(loggable))
 		q.impl.Delete(job)
-	} else if res.Status == ResultStatusPermanentFailure || !j.canRetry() {
+	} else if res.IsPermanentFailure() || !j.canRetry() {
 		q.stats.fail(1)
 		q.stats.permanentlyFail(1)
 		q.stats.complete(1)

--- a/jobqueue/result.go
+++ b/jobqueue/result.go
@@ -28,11 +28,6 @@ func (rslt *Result) IsFailure() bool {
 	return rslt.Status != ResultStatusSuccess
 }
 
-// IsPermanentFailure returns if the job is permanently failed.
-func (rslt *Result) IsPermanentFailure() bool {
-	return rslt.Status == ResultStatusPermanentFailure
-}
-
 // IsFinished returns if the job can be retried or not.
 func (rslt *Result) IsFinished() bool {
 	switch rslt.Status {

--- a/jobqueue/result.go
+++ b/jobqueue/result.go
@@ -23,9 +23,19 @@ type Result struct {
 	Message string `json:"message"`
 }
 
+// IsSuccess returns if the job succeeded
+func (rslt *Result) IsSuccess() bool {
+	return rslt.Status == ResultStatusSuccess
+}
+
 // IsFailure returns if the job is successfully processed or not.
 func (rslt *Result) IsFailure() bool {
 	return rslt.Status != ResultStatusSuccess
+}
+
+// IsPermanentFailure returns if the job is permanently failed.
+func (rslt *Result) IsPermanentFailure() bool {
+	return rslt.Status == ResultStatusPermanentFailure
 }
 
 // IsFinished returns if the job can be retried or not.


### PR DESCRIPTION
## What
Bug fix: A failed job is completed as `permanent failure` when its retry count is 0.