### PR TITLE
Add order parameter to jobs inspecting API

### DIFF
--- a/data/jobqueue/mysql/query/inspect_jobs_asc.sql
+++ b/data/jobqueue/mysql/query/inspect_jobs_asc.sql
@@ -1,0 +1,6 @@
+SELECT job_id FROM `{{.JobQueue}}`
+WHERE status = ?
+  AND next_try >= ?
+  AND next_try < ?
+  AND job_id >= ?
+ORDER BY next_try ASC, job_id ASC LIMIT

--- a/doc/api.md
+++ b/doc/api.md
@@ -381,7 +381,7 @@ Returns a list of grabbed jobs in a queue.  Grabbed jobs are running
 or be prepared to run.
 
 ```http
-GET /queue/test_queue1/grabbed?limit=10&cursor=MTQ5NzUxMDc4NiwxMw%3D%3D HTTP/1.1
+GET /queue/test_queue1/grabbed?limit=10&cursor=MTQ5NzUxMDc4NiwxMw%3D%3D&order=desc HTTP/1.1
 ```
 
 ```http
@@ -431,6 +431,7 @@ HTTP/1.1 200 OK
 |`queue_name`             |The name of the target queue.        |mandatory     |
 |`limit`                  |The maximum number of the jobs.      |default: `100`|
 |`cursor`                 |A cursor to retrieve next items since the previous request.  Specify the value of `next_cursor` field in the previous response.|optional|
+|`order`                  |Sort order of the jobs.              |default:`desc`|
 
 |Response code            |Meaning                              |
 |:------------------------|:------------------------------------|
@@ -444,7 +445,7 @@ but not grabbed yet just because there is not enough space or time to
 grab them.
 
 ```http
-GET /queue/test_queue1/waiting?limit=10&cursor=MTQ5NzUxMDc4NiwxMw%3D%3D HTTP/1.1
+GET /queue/test_queue1/waiting?limit=10&cursor=MTQ5NzUxMDc4NiwxMw%3D%3D&order=desc HTTP/1.1
 ```
 
 ```http
@@ -494,6 +495,7 @@ HTTP/1.1 200 OK
 |`queue_name`             |The name of the target queue.        |mandatory     |
 |`limit`                  |The maximum number of the jobs.      |default: `100`|
 |`cursor`                 |A cursor to retrieve next items since the previous request.  Specify the value of `next_cursor` field in the previous response.|optional|
+|`order`                  |Sort order of the jobs.              |default:`desc`|
 
 |Response code            |Meaning                              |
 |:------------------------|:------------------------------------|
@@ -506,7 +508,7 @@ Returns a list of deferred jobs in a queue.  Deferred jobs are not
 going to run for now because of specified delays.
 
 ```http
-GET /queue/test_queue1/deferred?limit=10&cursor=MTQ5NzUxMDc4NiwxMw%3D%3D HTTP/1.1
+GET /queue/test_queue1/deferred?limit=10&cursor=MTQ5NzUxMDc4NiwxMw%3D%3D&order=desc HTTP/1.1
 ```
 
 ```http
@@ -556,6 +558,7 @@ HTTP/1.1 200 OK
 |`queue_name`             |The name of the target queue.        |mandatory     |
 |`limit`                  |The maximum number of the jobs.      |default: `100`|
 |`cursor`                 |A cursor to retrieve next items since the previous request.  Specify the value of `next_cursor` field in the previous response.|optional|
+|`order`                  |Sort order of the jobs.              |default:`desc`|
 
 |Response code            |Meaning                              |
 |:------------------------|:------------------------------------|

--- a/jobqueue/inspector.go
+++ b/jobqueue/inspector.go
@@ -26,6 +26,15 @@ type InspectedJobs struct {
 	NextCursor string         `json:"next_cursor"`
 }
 
+// SortOrder describes sort order at inspecting jobs.
+type SortOrder int
+
+// Sort orders
+const (
+	Asc SortOrder = iota
+	Desc
+)
+
 // Inspector is an interface to inspect jobs in a queue.
 type Inspector interface {
 	Delete(jobID uint64) error

--- a/jobqueue/inspector.go
+++ b/jobqueue/inspector.go
@@ -39,9 +39,9 @@ const (
 type Inspector interface {
 	Delete(jobID uint64) error
 	Find(jobID uint64) (*InspectedJob, error)
-	FindAllGrabbed(limit uint, cursor string) (*InspectedJobs, error)
-	FindAllWaiting(limit uint, cursor string) (*InspectedJobs, error)
-	FindAllDeferred(limit uint, cursor string) (*InspectedJobs, error)
+	FindAllGrabbed(limit uint, cursor string, order SortOrder) (*InspectedJobs, error)
+	FindAllWaiting(limit uint, cursor string, order SortOrder) (*InspectedJobs, error)
+	FindAllDeferred(limit uint, cursor string, order SortOrder) (*InspectedJobs, error)
 }
 
 // HasInspector is an interface describing that it has an Inspector.

--- a/jobqueue/jobqueuetest/jobqueue_test.go
+++ b/jobqueue/jobqueuetest/jobqueue_test.go
@@ -77,7 +77,7 @@ func TestRecovering(t *testing.T) {
 		if !ok {
 			t.Error("Cannot get the inspector")
 		}
-		r, err := ins.FindAllGrabbed(10, "")
+		r, err := ins.FindAllGrabbed(10, "", jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
 		}
@@ -119,7 +119,7 @@ func TestInspecting(t *testing.T) {
 	}
 
 	func() {
-		r, err := ins.FindAllWaiting(2, "")
+		r, err := ins.FindAllWaiting(2, "", jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
 		}
@@ -134,7 +134,7 @@ func TestInspecting(t *testing.T) {
 			t.Errorf("Invalid order of jobs: %v", jobs)
 		}
 
-		r, err = ins.FindAllWaiting(2, r.NextCursor)
+		r, err = ins.FindAllWaiting(2, r.NextCursor, jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
 		}
@@ -164,7 +164,7 @@ func TestInspecting(t *testing.T) {
 	}()
 
 	func() {
-		r, err := ins.FindAllGrabbed(3, "")
+		r, err := ins.FindAllGrabbed(3, "", jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
 		}
@@ -182,7 +182,7 @@ func TestInspecting(t *testing.T) {
 			t.Errorf("Invalid order of jobs: %v", jobs)
 		}
 
-		r, err = ins.FindAllGrabbed(3, r.NextCursor)
+		r, err = ins.FindAllGrabbed(3, r.NextCursor, jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
 		}
@@ -212,7 +212,7 @@ func TestInspecting(t *testing.T) {
 	}()
 
 	func() {
-		r, err := ins.FindAllDeferred(2, "")
+		r, err := ins.FindAllDeferred(2, "", jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
 		}
@@ -227,7 +227,7 @@ func TestInspecting(t *testing.T) {
 			t.Errorf("Invalid order of jobs: %v", jobs)
 		}
 
-		r, err = ins.FindAllDeferred(2, r.NextCursor)
+		r, err = ins.FindAllDeferred(2, r.NextCursor, jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
 		}
@@ -257,7 +257,7 @@ func TestInspecting(t *testing.T) {
 	}()
 
 	func() {
-		r, err := ins.FindAllWaiting(10, "")
+		r, err := ins.FindAllWaiting(10, "", jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
 		}
@@ -277,7 +277,7 @@ func TestInspecting(t *testing.T) {
 	}()
 
 	func() {
-		r, err := ins.FindAllGrabbed(10, "")
+		r, err := ins.FindAllGrabbed(10, "", jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
 		}
@@ -297,7 +297,7 @@ func TestInspecting(t *testing.T) {
 	}()
 
 	func() {
-		r, err := ins.FindAllDeferred(10, "")
+		r, err := ins.FindAllDeferred(10, "", jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
 		}

--- a/jobqueue/jobqueuetest/jobqueue_test.go
+++ b/jobqueue/jobqueuetest/jobqueue_test.go
@@ -361,7 +361,7 @@ func TestInspecting(t *testing.T) {
 		if jobs[0].URL != "job2" {
 			t.Errorf("Invalid order of jobs: %v", jobs)
 		}
-		if jobs[1].URL != "job5" {
+		if jobs[1].URL != "job8" {
 			t.Errorf("Invalid order of jobs: %v", jobs)
 		}
 
@@ -376,7 +376,7 @@ func TestInspecting(t *testing.T) {
 		if len(jobs) != 3 {
 			t.Errorf("The number of jobs is incorrect: %d", len(jobs))
 		}
-		if jobs[2].URL != "job8" {
+		if jobs[2].URL != "job5" {
 			t.Errorf("Invalid order of jobs: %v", jobs)
 		}
 		if _, err := json.Marshal(r); err != nil {

--- a/jobqueue/jobqueuetest/jobqueue_test.go
+++ b/jobqueue/jobqueuetest/jobqueue_test.go
@@ -179,7 +179,7 @@ func TestInspecting(t *testing.T) {
 			t.Errorf("Invalid order of jobs: %v", jobs)
 		}
 
-		r, err = ins.FindAllWaiting(2, r.NextCursor, jobqueue.Desc)
+		r, err = ins.FindAllWaiting(2, r.NextCursor, jobqueue.Asc)
 		if err != nil {
 			t.Error(err)
 		}
@@ -275,7 +275,7 @@ func TestInspecting(t *testing.T) {
 			t.Errorf("Invalid order of jobs: %v", jobs)
 		}
 
-		r, err = ins.FindAllGrabbed(3, r.NextCursor, jobqueue.Desc)
+		r, err = ins.FindAllGrabbed(3, r.NextCursor, jobqueue.Asc)
 		if err != nil {
 			t.Error(err)
 		}
@@ -365,7 +365,7 @@ func TestInspecting(t *testing.T) {
 			t.Errorf("Invalid order of jobs: %v", jobs)
 		}
 
-		r, err = ins.FindAllDeferred(2, r.NextCursor, jobqueue.Desc)
+		r, err = ins.FindAllDeferred(2, r.NextCursor, jobqueue.Asc)
 		if err != nil {
 			t.Error(err)
 		}

--- a/jobqueue/jobqueuetest/jobqueue_test.go
+++ b/jobqueue/jobqueuetest/jobqueue_test.go
@@ -164,6 +164,51 @@ func TestInspecting(t *testing.T) {
 	}()
 
 	func() {
+		r, err := ins.FindAllWaiting(2, "", jobqueue.Asc)
+		if err != nil {
+			t.Error(err)
+		}
+		jobs := r.Jobs
+		if len(jobs) != 2 {
+			t.Errorf("The number of jobs is incorrect: %d", len(jobs))
+		}
+		if jobs[0].URL != "job6" {
+			t.Errorf("Invalid order of jobs: %v", jobs)
+		}
+		if jobs[1].URL != "job7" {
+			t.Errorf("Invalid order of jobs: %v", jobs)
+		}
+
+		r, err = ins.FindAllWaiting(2, r.NextCursor, jobqueue.Desc)
+		if err != nil {
+			t.Error(err)
+		}
+		if r.NextCursor != "" {
+			t.Error("Cursor should be empty when there is no more jobs")
+		}
+		jobs = append(jobs, r.Jobs...)
+		if len(jobs) != 3 {
+			t.Errorf("The number of jobs is incorrect: %d", len(jobs))
+		}
+		if jobs[2].URL != "job9" {
+			t.Errorf("Invalid order of jobs: %v", jobs)
+		}
+		if _, err := json.Marshal(r); err != nil {
+			t.Error(err)
+		}
+
+		for _, j := range jobs {
+			job, err := ins.Find(j.ID)
+			if err != nil {
+				t.Error(err)
+			}
+			if job.URL != j.URL {
+				t.Errorf("Wrong job: %v", job)
+			}
+		}
+	}()
+
+	func() {
 		r, err := ins.FindAllGrabbed(3, "", jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
@@ -212,6 +257,54 @@ func TestInspecting(t *testing.T) {
 	}()
 
 	func() {
+		r, err := ins.FindAllGrabbed(3, "", jobqueue.Asc)
+		if err != nil {
+			t.Error(err)
+		}
+		jobs := r.Jobs
+		if len(jobs) != 3 {
+			t.Errorf("The number of jobs is incorrect: %d", len(jobs))
+		}
+		if jobs[0].URL != "job0" {
+			t.Errorf("Invalid order of jobs: %v", jobs)
+		}
+		if jobs[1].URL != "job1" {
+			t.Errorf("Invalid order of jobs: %v", jobs)
+		}
+		if jobs[2].URL != "job3" {
+			t.Errorf("Invalid order of jobs: %v", jobs)
+		}
+
+		r, err = ins.FindAllGrabbed(3, r.NextCursor, jobqueue.Desc)
+		if err != nil {
+			t.Error(err)
+		}
+		if r.NextCursor != "" {
+			t.Error("Cursor should be empty when there is no more jobs")
+		}
+		jobs = append(jobs, r.Jobs...)
+		if len(jobs) != 4 {
+			t.Errorf("The number of jobs is incorrect: %d", len(jobs))
+		}
+		if jobs[3].URL != "job4" {
+			t.Errorf("Invalid order of jobs: %v", jobs)
+		}
+		if _, err := json.Marshal(r); err != nil {
+			t.Error(err)
+		}
+
+		for _, j := range jobs {
+			job, err := ins.Find(j.ID)
+			if err != nil {
+				t.Error(err)
+			}
+			if job.URL != j.URL {
+				t.Errorf("Wrong job: %v", job)
+			}
+		}
+	}()
+
+	func() {
 		r, err := ins.FindAllDeferred(2, "", jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
@@ -239,6 +332,51 @@ func TestInspecting(t *testing.T) {
 			t.Errorf("The number of jobs is incorrect: %d", len(jobs))
 		}
 		if jobs[2].URL != "job2" {
+			t.Errorf("Invalid order of jobs: %v", jobs)
+		}
+		if _, err := json.Marshal(r); err != nil {
+			t.Error(err)
+		}
+
+		for _, j := range jobs {
+			job, err := ins.Find(j.ID)
+			if err != nil {
+				t.Error(err)
+			}
+			if job.URL != j.URL {
+				t.Errorf("Wrong job: %v", job)
+			}
+		}
+	}()
+
+	func() {
+		r, err := ins.FindAllDeferred(2, "", jobqueue.Asc)
+		if err != nil {
+			t.Error(err)
+		}
+		jobs := r.Jobs
+		if len(jobs) != 2 {
+			t.Errorf("The number of jobs is incorrect: %d", len(jobs))
+		}
+		if jobs[0].URL != "job2" {
+			t.Errorf("Invalid order of jobs: %v", jobs)
+		}
+		if jobs[1].URL != "job5" {
+			t.Errorf("Invalid order of jobs: %v", jobs)
+		}
+
+		r, err = ins.FindAllDeferred(2, r.NextCursor, jobqueue.Desc)
+		if err != nil {
+			t.Error(err)
+		}
+		if r.NextCursor != "" {
+			t.Error("Cursor should be empty when there is no more jobs")
+		}
+		jobs = append(jobs, r.Jobs...)
+		if len(jobs) != 3 {
+			t.Errorf("The number of jobs is incorrect: %d", len(jobs))
+		}
+		if jobs[2].URL != "job8" {
 			t.Errorf("Invalid order of jobs: %v", jobs)
 		}
 		if _, err := json.Marshal(r); err != nil {

--- a/jobqueue/mysql/inspector.go
+++ b/jobqueue/mysql/inspector.go
@@ -36,17 +36,17 @@ func (i *inspector) Find(jobID uint64) (*jobqueue.InspectedJob, error) {
 	return j, nil
 }
 
-func (i *inspector) FindAllGrabbed(limit uint, cursor string) (*jobqueue.InspectedJobs, error) {
+func (i *inspector) FindAllGrabbed(limit uint, cursor string, order jobqueue.SortOrder) (*jobqueue.InspectedJobs, error) {
 	var maxTime = time.Now().UnixNano() / int64(time.Millisecond)
 	return i.findAll("grabbed", 0, maxTime, limit, cursor)
 }
 
-func (i *inspector) FindAllWaiting(limit uint, cursor string) (*jobqueue.InspectedJobs, error) {
+func (i *inspector) FindAllWaiting(limit uint, cursor string, order jobqueue.SortOrder) (*jobqueue.InspectedJobs, error) {
 	var maxTime = time.Now().UnixNano() / int64(time.Millisecond)
 	return i.findAll("claimed", 0, maxTime, limit, cursor)
 }
 
-func (i *inspector) FindAllDeferred(limit uint, cursor string) (*jobqueue.InspectedJobs, error) {
+func (i *inspector) FindAllDeferred(limit uint, cursor string, order jobqueue.SortOrder) (*jobqueue.InspectedJobs, error) {
 	var minTime = time.Now().UnixNano() / int64(time.Millisecond)
 	return i.findAll("claimed", minTime, 0, limit, cursor)
 }

--- a/jobqueue/mysql/inspector.go
+++ b/jobqueue/mysql/inspector.go
@@ -60,25 +60,21 @@ func (i *inspector) FindAllDeferred(limit uint, cursor string, order jobqueue.So
 	return i.findAllDesc("claimed", minTime, 0, limit, cursor)
 }
 
-func decodeCursor(cursor string, time *int64, jobID *uint64) {
-	if decoded, err := base64.StdEncoding.DecodeString(cursor); err == nil {
-		if pair := strings.SplitN(string(decoded), ",", 2); len(pair) == 2 {
-			t, err1 := strconv.Atoi(pair[0])
-			j, err2 := strconv.Atoi(pair[1])
-			if err1 == nil && err2 == nil {
-				*time = int64(t)
-				*jobID = uint64(j)
-			}
-		}
-	}
-}
-
 func (i *inspector) findAllAsc(status string, minTime int64, maxTime int64, limit uint, cursor string) (*jobqueue.InspectedJobs, error) {
 	if minTime >= math.MaxInt64 {
 		minTime = 0
 	}
 	var minJobID uint64
-	decodeCursor(cursor, &minTime, &minJobID)
+	if decoded, err := base64.StdEncoding.DecodeString(cursor); err == nil {
+		if pair := strings.SplitN(string(decoded), ",", 2); len(pair) == 2 {
+			t, err1 := strconv.Atoi(pair[0])
+			j, err2 := strconv.Atoi(pair[1])
+			if err1 == nil && err2 == nil {
+				minTime = int64(t)
+				minJobID = uint64(j)
+			}
+		}
+	}
 
 	ids := make([]interface{}, 0, limit+1)
 	placeholders := make([]string, 0, limit+1)
@@ -170,7 +166,16 @@ func (i *inspector) findAllDesc(status string, minTime int64, maxTime int64, lim
 	}
 
 	var maxJobID uint64 = math.MaxUint64
-	decodeCursor(cursor, &maxTime, &maxJobID)
+	if decoded, err := base64.StdEncoding.DecodeString(cursor); err == nil {
+		if pair := strings.SplitN(string(decoded), ",", 2); len(pair) == 2 {
+			t, err1 := strconv.Atoi(pair[0])
+			j, err2 := strconv.Atoi(pair[1])
+			if err1 == nil && err2 == nil {
+				maxTime = int64(t)
+				maxJobID = uint64(j)
+			}
+		}
+	}
 
 	ids := make([]interface{}, 0, limit+1)
 	placeholders := make([]string, 0, limit+1)

--- a/jobqueue/mysql/sql.go
+++ b/jobqueue/mysql/sql.go
@@ -44,6 +44,7 @@ func (tn *tableName) makeQueries() *sqls {
 		recover:            tn.makeQuery(tmplRecoverJobs),
 		inspectJob:         tn.makeQuery(tmplInspectJob),
 		inspectJobs:        tn.makeQuery(tmplInspectJobs),
+		inspectJobsAsc:     tn.makeQuery(tmplInspectJobsAsc),
 		failedJob:          tn.makeQuery(tmplFailedJob),
 		failedJobs:         tn.makeQuery(tmplFailedJobs),
 		recentlyFailedJobs: tn.makeQuery(tmplRecentlyFailedJobs),
@@ -71,6 +72,7 @@ type sqls struct {
 	recover            string
 	inspectJob         string
 	inspectJobs        string
+	inspectJobsAsc     string
 	failedJob          string
 	failedJobs         string
 	recentlyFailedJobs string
@@ -92,6 +94,7 @@ var (
 	tmplRecoverJobs        *template.Template
 	tmplInspectJob         *template.Template
 	tmplInspectJobs        *template.Template
+	tmplInspectJobsAsc     *template.Template
 	tmplFailedJob          *template.Template
 	tmplFailedJobs         *template.Template
 	tmplRecentlyFailedJobs *template.Template
@@ -131,6 +134,7 @@ func init() {
 	tmplRecoverJobs = mustLoadTemplate("query/recover_jobs")
 	tmplInspectJob = mustLoadTemplate("query/inspect_job")
 	tmplInspectJobs = mustLoadTemplate("query/inspect_jobs")
+	tmplInspectJobsAsc = mustLoadTemplate("query/inspect_jobs_asc")
 	tmplFailedJob = mustLoadTemplate("query/failed_job")
 	tmplFailedJobs = mustLoadTemplate("query/failed_jobs")
 	tmplRecentlyFailedJobs = mustLoadTemplate("query/recently_failed_jobs")

--- a/test/jobqueue/jobqueue.go
+++ b/test/jobqueue/jobqueue.go
@@ -250,7 +250,7 @@ func subtestDelete1(t *testing.T, jq jobqueue.Impl) {
 	if hasInspector, ok := jq.(jobqueue.HasInspector); ok {
 		i := hasInspector.Inspector()
 
-		r1, err := i.FindAllGrabbed(uint(100), "")
+		r1, err := i.FindAllGrabbed(uint(100), "", jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
 		}
@@ -258,12 +258,12 @@ func subtestDelete1(t *testing.T, jq jobqueue.Impl) {
 			t.Error("There must be no grabbed job in the queue")
 		}
 
-		r2, err := i.FindAllWaiting(uint(100), "")
+		r2, err := i.FindAllWaiting(uint(100), "", jobqueue.Desc)
 		if len(r2.Jobs) != 0 {
 			t.Error("There must be no waiting job in the queue")
 		}
 
-		r3, err := i.FindAllDeferred(uint(100), "")
+		r3, err := i.FindAllDeferred(uint(100), "", jobqueue.Desc)
 		if len(r3.Jobs) != 0 {
 			t.Error("There must be no deferred job in the queue")
 		}
@@ -291,7 +291,7 @@ func subtestDeletePartially(t *testing.T, jq jobqueue.Impl) {
 	if hasInspector, ok := jq.(jobqueue.HasInspector); ok {
 		i := hasInspector.Inspector()
 
-		r1, err := i.FindAllGrabbed(uint(100), "")
+		r1, err := i.FindAllGrabbed(uint(100), "", jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
 		}
@@ -299,12 +299,12 @@ func subtestDeletePartially(t *testing.T, jq jobqueue.Impl) {
 			t.Error("There must be only one grabbed job in the queue")
 		}
 
-		r2, err := i.FindAllWaiting(uint(100), "")
+		r2, err := i.FindAllWaiting(uint(100), "", jobqueue.Desc)
 		if len(r2.Jobs) != 1 {
 			t.Error("There must be one waiting job in the queue")
 		}
 
-		r3, err := i.FindAllDeferred(uint(100), "")
+		r3, err := i.FindAllDeferred(uint(100), "", jobqueue.Desc)
 		if len(r3.Jobs) != 0 {
 			t.Error("There must be no deferred job in the queue")
 		}
@@ -333,7 +333,7 @@ func subtestDeleteMulti(t *testing.T, jq jobqueue.Impl) {
 	if hasInspector, ok := jq.(jobqueue.HasInspector); ok {
 		i := hasInspector.Inspector()
 
-		r1, err := i.FindAllGrabbed(uint(100), "")
+		r1, err := i.FindAllGrabbed(uint(100), "", jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
 		}
@@ -341,12 +341,12 @@ func subtestDeleteMulti(t *testing.T, jq jobqueue.Impl) {
 			t.Error("There must be only one grabbed job in the queue")
 		}
 
-		r2, err := i.FindAllWaiting(uint(100), "")
+		r2, err := i.FindAllWaiting(uint(100), "", jobqueue.Desc)
 		if len(r2.Jobs) != 2 {
 			t.Error("There must be two waiting jobs in the queue")
 		}
 
-		r3, err := i.FindAllDeferred(uint(100), "")
+		r3, err := i.FindAllDeferred(uint(100), "", jobqueue.Desc)
 		if len(r3.Jobs) != 0 {
 			t.Error("There must be no deferred jobs in the queue")
 		}
@@ -366,7 +366,7 @@ func subtestDeleteMulti(t *testing.T, jq jobqueue.Impl) {
 	if hasInspector, ok := jq.(jobqueue.HasInspector); ok {
 		i := hasInspector.Inspector()
 
-		r1, err := i.FindAllGrabbed(uint(100), "")
+		r1, err := i.FindAllGrabbed(uint(100), "", jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
 		}
@@ -374,12 +374,12 @@ func subtestDeleteMulti(t *testing.T, jq jobqueue.Impl) {
 			t.Error("There must be only one grabbed job in the queue")
 		}
 
-		r2, err := i.FindAllWaiting(uint(100), "")
+		r2, err := i.FindAllWaiting(uint(100), "", jobqueue.Desc)
 		if len(r2.Jobs) != 0 {
 			t.Error("There must be no waiting job in the queue")
 		}
 
-		r3, err := i.FindAllDeferred(uint(100), "")
+		r3, err := i.FindAllDeferred(uint(100), "", jobqueue.Desc)
 		if len(r3.Jobs) != 0 {
 			t.Error("There must be no deferred job in the queue")
 		}
@@ -582,7 +582,7 @@ func subtestAsyncDelete1(t *testing.T, jq jobqueue.Impl) {
 	if hasInspector, ok := jq.(jobqueue.HasInspector); ok {
 		i := hasInspector.Inspector()
 
-		r1, err := i.FindAllGrabbed(uint(100), "")
+		r1, err := i.FindAllGrabbed(uint(100), "", jobqueue.Desc)
 		if err != nil {
 			t.Error(err)
 		}
@@ -590,12 +590,12 @@ func subtestAsyncDelete1(t *testing.T, jq jobqueue.Impl) {
 			t.Error("There must be no grabbed job in the queue")
 		}
 
-		r2, err := i.FindAllWaiting(uint(100), "")
+		r2, err := i.FindAllWaiting(uint(100), "", jobqueue.Desc)
 		if len(r2.Jobs) != 0 {
 			t.Error("There must be no waiting job in the queue")
 		}
 
-		r3, err := i.FindAllDeferred(uint(100), "")
+		r3, err := i.FindAllDeferred(uint(100), "", jobqueue.Desc)
 		if len(r3.Jobs) != 0 {
 			t.Error("There must be no deferred job in the queue")
 		}

--- a/web/queue.go
+++ b/web/queue.go
@@ -185,7 +185,15 @@ func (app *Application) serveQueueJobs(find func(jobqueue.Inspector, uint, strin
 		limit = uint(l)
 	}
 
-	jobs, err := find(inspector, limit, query.Get("cursor"), jobqueue.Desc)
+	order := jobqueue.Desc
+	switch o := query.Get("order"); o {
+	case "asc":
+		order = jobqueue.Asc
+	case "desc":
+		order = jobqueue.Desc
+	}
+
+	jobs, err := find(inspector, limit, query.Get("cursor"), order)
 	if err != nil {
 		return err
 	}

--- a/web/queue.go
+++ b/web/queue.go
@@ -149,24 +149,24 @@ func (app *Application) serveQueueStats(w http.ResponseWriter, req *http.Request
 }
 
 func (app *Application) serveQueueGrabbed(w http.ResponseWriter, req *http.Request) error {
-	return app.serveQueueJobs(func(i jobqueue.Inspector, l uint, c string) (*jobqueue.InspectedJobs, error) {
-		return i.FindAllGrabbed(l, c)
+	return app.serveQueueJobs(func(i jobqueue.Inspector, l uint, c string, o jobqueue.SortOrder) (*jobqueue.InspectedJobs, error) {
+		return i.FindAllGrabbed(l, c, o)
 	}, w, req)
 }
 
 func (app *Application) serveQueueWaiting(w http.ResponseWriter, req *http.Request) error {
-	return app.serveQueueJobs(func(i jobqueue.Inspector, l uint, c string) (*jobqueue.InspectedJobs, error) {
-		return i.FindAllWaiting(l, c)
+	return app.serveQueueJobs(func(i jobqueue.Inspector, l uint, c string, o jobqueue.SortOrder) (*jobqueue.InspectedJobs, error) {
+		return i.FindAllWaiting(l, c, o)
 	}, w, req)
 }
 
 func (app *Application) serveQueueDeferred(w http.ResponseWriter, req *http.Request) error {
-	return app.serveQueueJobs(func(i jobqueue.Inspector, l uint, c string) (*jobqueue.InspectedJobs, error) {
-		return i.FindAllDeferred(l, c)
+	return app.serveQueueJobs(func(i jobqueue.Inspector, l uint, c string, o jobqueue.SortOrder) (*jobqueue.InspectedJobs, error) {
+		return i.FindAllDeferred(l, c, o)
 	}, w, req)
 }
 
-func (app *Application) serveQueueJobs(find func(jobqueue.Inspector, uint, string) (*jobqueue.InspectedJobs, error), w http.ResponseWriter, req *http.Request) error {
+func (app *Application) serveQueueJobs(find func(jobqueue.Inspector, uint, string, jobqueue.SortOrder) (*jobqueue.InspectedJobs, error), w http.ResponseWriter, req *http.Request) error {
 	vars := mux.Vars(req)
 	query := req.URL.Query()
 
@@ -185,7 +185,7 @@ func (app *Application) serveQueueJobs(find func(jobqueue.Inspector, uint, strin
 		limit = uint(l)
 	}
 
-	jobs, err := find(inspector, limit, query.Get("cursor"))
+	jobs, err := find(inspector, limit, query.Get("cursor"), jobqueue.Desc)
 	if err != nil {
 		return err
 	}

--- a/web/queue_test.go
+++ b/web/queue_test.go
@@ -1005,6 +1005,76 @@ func TestGetQueueGrabbed(t *testing.T) {
 			}
 		}
 	}()
+
+	func() {
+		ctrl := gomock.NewController(t)
+		s, mockApp := newMockServer(ctrl)
+		defer s.Close()
+
+		jobs := &jobqueue.InspectedJobs{
+			Jobs: []jobqueue.InspectedJob{
+				{
+					ID:       1,
+					Category: "test_job",
+					URL:      "http://example.com/",
+				},
+				{
+					ID:       2,
+					Category: "test_job",
+					URL:      "http://example.com/",
+				},
+				{
+					ID:       3,
+					Category: "test_job",
+					URL:      "http://example.com/",
+				},
+			},
+			NextCursor: "",
+		}
+
+		limit := uint(123)
+		cursor := "bar"
+
+		mockInspector := NewMockInspector(ctrl)
+		mockInspector.EXPECT().
+			FindAllGrabbed(limit, cursor, jobqueue.Asc).
+			Return(jobs, nil)
+
+		mockJobQueue := NewMockJobQueue(ctrl)
+		mockJobQueue.EXPECT().
+			Inspector().
+			Return(mockInspector, true)
+
+		mockApp.Service.EXPECT().
+			GetJobQueue(gomock.Any()).
+			Return(newMockRunningQueue(mockJobQueue, nil), true)
+
+		resp, err := http.Get(s.URL + "/queue/queue1/grabbed?order=asc&cursor=" + cursor + "&limit=" + strconv.Itoa(int(limit)))
+		if err != nil {
+			t.Error(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Error("GET /queue/$name/grabbed should succeed")
+		}
+
+		var result jobqueue.InspectedJobs
+		buf, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		if err := json.Unmarshal(buf, &result); err != nil {
+			t.Error(err)
+		}
+		if len(result.Jobs) != len(jobs.Jobs) {
+			t.Errorf("GET /queue/$name/grabbed should return grabbed jobs: %v", result)
+		}
+		for i, f := range result.Jobs {
+			if f.ID != jobs.Jobs[i].ID {
+				t.Errorf("GET /queue/$name/grabbed should return grabbed jobs: %v", f)
+			}
+		}
+	}()
 }
 
 func TestGetQueueWaiting(t *testing.T) {
@@ -1216,6 +1286,76 @@ func TestGetQueueWaiting(t *testing.T) {
 			}
 		}
 	}()
+
+	func() {
+		ctrl := gomock.NewController(t)
+		s, mockApp := newMockServer(ctrl)
+		defer s.Close()
+
+		jobs := &jobqueue.InspectedJobs{
+			Jobs: []jobqueue.InspectedJob{
+				{
+					ID:       1,
+					Category: "test_job",
+					URL:      "http://example.com/",
+				},
+				{
+					ID:       2,
+					Category: "test_job",
+					URL:      "http://example.com/",
+				},
+				{
+					ID:       3,
+					Category: "test_job",
+					URL:      "http://example.com/",
+				},
+			},
+			NextCursor: "",
+		}
+
+		limit := uint(123)
+		cursor := "bar"
+
+		mockInspector := NewMockInspector(ctrl)
+		mockInspector.EXPECT().
+			FindAllWaiting(limit, cursor, jobqueue.Asc).
+			Return(jobs, nil)
+
+		mockJobQueue := NewMockJobQueue(ctrl)
+		mockJobQueue.EXPECT().
+			Inspector().
+			Return(mockInspector, true)
+
+		mockApp.Service.EXPECT().
+			GetJobQueue(gomock.Any()).
+			Return(newMockRunningQueue(mockJobQueue, nil), true)
+
+		resp, err := http.Get(s.URL + "/queue/queue1/waiting?order=asc&cursor=" + cursor + "&limit=" + strconv.Itoa(int(limit)))
+		if err != nil {
+			t.Error(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Error("GET /queue/$name/waiting should succeed")
+		}
+
+		var result jobqueue.InspectedJobs
+		buf, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		if err := json.Unmarshal(buf, &result); err != nil {
+			t.Error(err)
+		}
+		if len(result.Jobs) != len(jobs.Jobs) {
+			t.Errorf("GET /queue/$name/waiting should return waiting jobs: %v", result)
+		}
+		for i, f := range result.Jobs {
+			if f.ID != jobs.Jobs[i].ID {
+				t.Errorf("GET /queue/$name/waiting should return waiting jobs: %v", f)
+			}
+		}
+	}()
 }
 
 func TestGetQueueDeferred(t *testing.T) {
@@ -1401,6 +1541,76 @@ func TestGetQueueDeferred(t *testing.T) {
 			Return(newMockRunningQueue(mockJobQueue, nil), true)
 
 		resp, err := http.Get(s.URL + "/queue/queue1/deferred?cursor=" + cursor + "&limit=" + strconv.Itoa(int(limit)))
+		if err != nil {
+			t.Error(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Error("GET /queue/$name/deferred should succeed")
+		}
+
+		var result jobqueue.InspectedJobs
+		buf, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		if err := json.Unmarshal(buf, &result); err != nil {
+			t.Error(err)
+		}
+		if len(result.Jobs) != len(jobs.Jobs) {
+			t.Errorf("GET /queue/$name/deferred should return deferred jobs: %v", result)
+		}
+		for i, f := range result.Jobs {
+			if f.ID != jobs.Jobs[i].ID {
+				t.Errorf("GET /queue/$name/deferred should return deferred jobs: %v", f)
+			}
+		}
+	}()
+
+	func() {
+		ctrl := gomock.NewController(t)
+		s, mockApp := newMockServer(ctrl)
+		defer s.Close()
+
+		jobs := &jobqueue.InspectedJobs{
+			Jobs: []jobqueue.InspectedJob{
+				{
+					ID:       1,
+					Category: "test_job",
+					URL:      "http://example.com/",
+				},
+				{
+					ID:       2,
+					Category: "test_job",
+					URL:      "http://example.com/",
+				},
+				{
+					ID:       3,
+					Category: "test_job",
+					URL:      "http://example.com/",
+				},
+			},
+			NextCursor: "",
+		}
+
+		limit := uint(123)
+		cursor := "bar"
+
+		mockInspector := NewMockInspector(ctrl)
+		mockInspector.EXPECT().
+			FindAllDeferred(limit, cursor, jobqueue.Asc).
+			Return(jobs, nil)
+
+		mockJobQueue := NewMockJobQueue(ctrl)
+		mockJobQueue.EXPECT().
+			Inspector().
+			Return(mockInspector, true)
+
+		mockApp.Service.EXPECT().
+			GetJobQueue(gomock.Any()).
+			Return(newMockRunningQueue(mockJobQueue, nil), true)
+
+		resp, err := http.Get(s.URL + "/queue/queue1/deferred?order=asc&cursor=" + cursor + "&limit=" + strconv.Itoa(int(limit)))
 		if err != nil {
 			t.Error(err)
 		}

--- a/web/queue_test.go
+++ b/web/queue_test.go
@@ -847,7 +847,7 @@ func TestGetQueueGrabbed(t *testing.T) {
 
 		mockInspector := NewMockInspector(ctrl)
 		mockInspector.EXPECT().
-			FindAllGrabbed(gomock.Any(), "").
+			FindAllGrabbed(gomock.Any(), "", jobqueue.Desc).
 			Return(nil, errors.New("FindAllGrabbed() failure"))
 
 		mockJobQueue := NewMockJobQueue(ctrl)
@@ -897,7 +897,7 @@ func TestGetQueueGrabbed(t *testing.T) {
 
 		mockInspector := NewMockInspector(ctrl)
 		mockInspector.EXPECT().
-			FindAllGrabbed(gomock.Any(), "").
+			FindAllGrabbed(gomock.Any(), "", jobqueue.Desc).
 			Return(jobs, nil)
 
 		mockJobQueue := NewMockJobQueue(ctrl)
@@ -967,7 +967,7 @@ func TestGetQueueGrabbed(t *testing.T) {
 
 		mockInspector := NewMockInspector(ctrl)
 		mockInspector.EXPECT().
-			FindAllGrabbed(limit, cursor).
+			FindAllGrabbed(limit, cursor, jobqueue.Desc).
 			Return(jobs, nil)
 
 		mockJobQueue := NewMockJobQueue(ctrl)
@@ -1058,7 +1058,7 @@ func TestGetQueueWaiting(t *testing.T) {
 
 		mockInspector := NewMockInspector(ctrl)
 		mockInspector.EXPECT().
-			FindAllWaiting(gomock.Any(), "").
+			FindAllWaiting(gomock.Any(), "", jobqueue.Desc).
 			Return(nil, errors.New("FindAllWating() failure"))
 
 		mockJobQueue := NewMockJobQueue(ctrl)
@@ -1108,7 +1108,7 @@ func TestGetQueueWaiting(t *testing.T) {
 
 		mockInspector := NewMockInspector(ctrl)
 		mockInspector.EXPECT().
-			FindAllWaiting(gomock.Any(), "").
+			FindAllWaiting(gomock.Any(), "", jobqueue.Desc).
 			Return(jobs, nil)
 
 		mockJobQueue := NewMockJobQueue(ctrl)
@@ -1178,7 +1178,7 @@ func TestGetQueueWaiting(t *testing.T) {
 
 		mockInspector := NewMockInspector(ctrl)
 		mockInspector.EXPECT().
-			FindAllWaiting(limit, cursor).
+			FindAllWaiting(limit, cursor, jobqueue.Desc).
 			Return(jobs, nil)
 
 		mockJobQueue := NewMockJobQueue(ctrl)
@@ -1269,7 +1269,7 @@ func TestGetQueueDeferred(t *testing.T) {
 
 		mockInspector := NewMockInspector(ctrl)
 		mockInspector.EXPECT().
-			FindAllDeferred(gomock.Any(), "").
+			FindAllDeferred(gomock.Any(), "", jobqueue.Desc).
 			Return(nil, errors.New("FindAllDeferred() failure"))
 
 		mockJobQueue := NewMockJobQueue(ctrl)
@@ -1318,7 +1318,7 @@ func TestGetQueueDeferred(t *testing.T) {
 
 		mockInspector := NewMockInspector(ctrl)
 		mockInspector.EXPECT().
-			FindAllDeferred(gomock.Any(), "").
+			FindAllDeferred(gomock.Any(), "", jobqueue.Desc).
 			Return(jobs, nil)
 
 		mockJobQueue := NewMockJobQueue(ctrl)
@@ -1388,7 +1388,7 @@ func TestGetQueueDeferred(t *testing.T) {
 
 		mockInspector := NewMockInspector(ctrl)
 		mockInspector.EXPECT().
-			FindAllDeferred(limit, cursor).
+			FindAllDeferred(limit, cursor, jobqueue.Desc).
 			Return(jobs, nil)
 
 		mockJobQueue := NewMockJobQueue(ctrl)


### PR DESCRIPTION
# What
- I introduce new `order` parameter for jobs inspecting API. We can inspect jobs in arbitrary order by `fnext_try` field.

# Why
- I want to seek some job, for example, waiting job that will grab next time.
- `/queue/default/waiting?order=asc&limit=1` satisfies the behavior. 