### PR TITLE
Must get golang/mock@1.3.0 before run make credits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ release: clean deps credits generate
 credits:
 	GOOS= GOARCH= ${GO} run script/genauthors/genauthors.go > AUTHORS
 	GO111MODULE=off GOOS= GOARCH= ${GO} get github.com/Songmu/gocredits/cmd/gocredits
-	go mod tidy # not `go get` to get all the dependencies regardress of OS, architecture and build tags
+	${GO} mod tidy # not `go get` to get all the dependencies regardress of OS, architecture and build tags
 	gocredits -w .
 
 generate:

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ release: clean deps credits generate
 credits:
 	GOOS= GOARCH= ${GO} run script/genauthors/genauthors.go > AUTHORS
 	GO111MODULE=off GOOS= GOARCH= ${GO} get github.com/Songmu/gocredits/cmd/gocredits
+	go mod tidy # not `go get` to get all the dependencies regardress of OS, architecture and build tags
 	gocredits -w .
 
 generate:


### PR DESCRIPTION
# What
- Make sure dependencies of gocredits when `make credits`.

# Why

- I got an error like below when trying release next version.
- We need to install `golang/mock@v1.3.0`. And `go mod` installs the library when `make release` (= `go build`). But the task depends `make credits`, then does not found the library at `make credits`.
- This bug had introduced: https://github.com/fireworq/fireworq/pull/32

```
GO111MODULE=off GOOS= GOARCH= go get github.com/Songmu/gocredits/cmd/gocredits
gocredits -w .
open /go/pkg/mod/github.com/golang/mock@v1.3.0: no such file or directory
make: *** [Makefile:32: credits] Error 1
+status=2
```