### PR TITLE
Improve the dispatcher performance when using keep alive

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -203,7 +203,7 @@ Specifies whether a connection to a worker should be reused.  This overrides [th
 		defaultValue: "10",
 		label:        "<number>",
 		description: `
-Specifies maximum idle connections to keep per-host.
+Specifies maximum idle connections to keep per-host. This value work only when [connections of the dispatcher are reused](#env-dispatch-keep-alive).
 `,
 	},
 	"dispatch_idle_conn_timeout": {
@@ -211,7 +211,7 @@ Specifies maximum idle connections to keep per-host.
 		defaultValue: "0",
 		label:        "<seconds>",
 		description: `
-Specifies the maximum time of an idle (keep-alive) connections. If zero, an idle connections will not be closed. 
+Specifies the maximum amount of time of an idle (keep-alive) connection will remain idle before closing itself. If zero, an idle connections will not be closed. 
 `,
 	},
 }

--- a/config/default.go
+++ b/config/default.go
@@ -206,4 +206,12 @@ Specifies whether a connection to a worker should be reused.  This overrides [th
 Specifies maximum idle connections to keep per-host.
 `,
 	},
+	"dispatch_idle_conn_timeout": {
+		category:     "common",
+		defaultValue: "0",
+		label:        "<seconds>",
+		description: `
+Specifies the maximum time of an idle (keep-alive) connections. If zero, an idle connections will not be closed. 
+`,
+	},
 }

--- a/config/default.go
+++ b/config/default.go
@@ -198,4 +198,12 @@ Specifies the value of ` + "`" + `User-Agent` + "`" + ` header field used for an
 Specifies whether a connection to a worker should be reused.  This overrides [the default keep-alive setting](#env-keep-alive).
 `,
 	},
+	"dispatch_max_conns_per_host": {
+		category:     "common",
+		defaultValue: "10",
+		label:        "<number>",
+		description: `
+Specifies maximum idle connections to keep per-host.
+`,
+	},
 }

--- a/config/default.go
+++ b/config/default.go
@@ -203,7 +203,7 @@ Specifies whether a connection to a worker should be reused.  This overrides [th
 		defaultValue: "10",
 		label:        "<number>",
 		description: `
-Specifies maximum idle connections to keep per-host. This value work only when [connections of the dispatcher are reused](#env-dispatch-keep-alive).
+Specifies maximum idle connections to keep per-host. This value works only when [connections of the dispatcher are reused](#env-dispatch-keep-alive).
 `,
 	},
 	"dispatch_idle_conn_timeout": {

--- a/dispatcher/worker/http.go
+++ b/dispatcher/worker/http.go
@@ -37,6 +37,12 @@ func HTTPInit() {
 	}
 	transport.MaxIdleConnsPerHost = int(v)
 
+	v, err = strconv.ParseInt(config.Get("dispatch_idle_conn_timeout"), 10, 32)
+	if err != nil {
+		v, _ = strconv.ParseInt(config.GetDefault("dispatch_idle_conn_timeout"), 10, 32)
+	}
+	transport.IdleConnTimeout = time.Duration(v) * time.Second
+
 	defaultUserAgent = config.Get("dispatch_user_agent")
 }
 

--- a/dispatcher/worker/http.go
+++ b/dispatcher/worker/http.go
@@ -23,12 +23,19 @@ var defaultUserAgent string
 // Configuration keys prefixed by "dispatch_" are considered.
 func HTTPInit() {
 	transport := http.DefaultTransport.(*http.Transport)
+	transport.MaxIdleConns = 0
 
 	b, err := strconv.ParseBool(config.Get("dispatch_keep_alive"))
 	if err != nil {
 		b, _ = strconv.ParseBool(config.GetDefault("dispatch_keep_alive"))
 	}
 	transport.DisableKeepAlives = !b
+
+	v, err := strconv.ParseInt(config.Get("dispatch_max_conns_per_host"), 10, 32)
+	if err != nil {
+		v, _ = strconv.ParseInt(config.GetDefault("dispatch_max_conns_per_host"), 10, 32)
+	}
+	transport.MaxIdleConnsPerHost = int(v)
 
 	defaultUserAgent = config.Get("dispatch_user_agent")
 }

--- a/dispatcher/worker/http_test.go
+++ b/dispatcher/worker/http_test.go
@@ -18,6 +18,44 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func TestHTTPInit(t *testing.T) {
+	config.Locally("dispatch_max_conns_per_host", "foo", func() {
+		HTTPInit()
+
+		transport := http.DefaultTransport.(*http.Transport)
+		if transport.MaxIdleConnsPerHost != 10 {
+			t.Error("Not set a default value to MaxIdleConnsPerHost")
+		}
+	})
+
+	config.Locally("dispatch_max_conns_per_host", "1000", func() {
+		HTTPInit()
+
+		transport := http.DefaultTransport.(*http.Transport)
+		if transport.MaxIdleConnsPerHost != 1000 {
+			t.Error("Not set to MaxIdleConnsPerHost")
+		}
+	})
+
+	config.Locally("dispatch_idle_conn_timeout", "foo", func() {
+		HTTPInit()
+
+		transport := http.DefaultTransport.(*http.Transport)
+		if transport.IdleConnTimeout != 0 {
+			t.Error("Not set a default value to IdleConnTimeout")
+		}
+	})
+
+	config.Locally("dispatch_idle_conn_timeout", "10", func() {
+		HTTPInit()
+
+		transport := http.DefaultTransport.(*http.Transport)
+		if transport.IdleConnTimeout != 10*time.Second {
+			t.Error("Not set to IdleConnTimeout")
+		}
+	})
+}
+
 func TestNewWorker(t *testing.T) {
 	func() {
 		w0 := &HTTPWorker{}

--- a/doc/config.md
+++ b/doc/config.md
@@ -55,7 +55,7 @@ Specifies the value of `tag` field in a access log item.
 ### <a name="env-dispatch-idle-conn-timeout">`FIREWORQ_DISPATCH_IDLE_CONN_TIMEOUT`, `--dispatch-idle-conn-timeout`</a>
 Default: `0`
 
-Specifies the maximum time of an idle (keep-alive) connections. If zero, an idle connections will not be closed. 
+Specifies the maximum amount of time of an idle (keep-alive) connection will remain idle before closing itself. If zero, an idle connections will not be closed. 
 
 ### <a name="env-dispatch-keep-alive">`FIREWORQ_DISPATCH_KEEP_ALIVE`, `--dispatch-keep-alive`</a>
 
@@ -64,7 +64,7 @@ Specifies whether a connection to a worker should be reused.  This overrides [th
 ### <a name="env-dispatch-max-conns-per-host">`FIREWORQ_DISPATCH_MAX_CONNS_PER_HOST`, `--dispatch-max-conns-per-host`</a>
 Default: `10`
 
-Specifies maximum idle connections to keep per-host.
+Specifies maximum idle connections to keep per-host. This value work only when [connections of the dispatcher are reused](#env-dispatch-keep-alive).
 
 ### <a name="env-dispatch-user-agent">`FIREWORQ_DISPATCH_USER_AGENT`, `--dispatch-user-agent`</a>
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -15,6 +15,7 @@ applicable only to a [manual setup][section-manual-setup].
 - [Common Variables/Arguments][section-config-common]
   - [`FIREWORQ_ACCESS_LOG`, `--access-log`](#env-access-log)
   - [`FIREWORQ_ACCESS_LOG_TAG`, `--access-log-tag`](#env-access-log-tag)
+  - [`FIREWORQ_DISPATCH_IDLE_CONN_TIMEOUT`, `--dispatch-idle-conn-timeout`](#env-dispatch-idle-conn-timeout)
   - [`FIREWORQ_DISPATCH_KEEP_ALIVE`, `--dispatch-keep-alive`](#env-dispatch-keep-alive)
   - [`FIREWORQ_DISPATCH_MAX_CONNS_PER_HOST`, `--dispatch-max-conns-per-host`](#env-dispatch-max-conns-per-host)
   - [`FIREWORQ_DISPATCH_USER_AGENT`, `--dispatch-user-agent`](#env-dispatch-user-agent)
@@ -50,6 +51,11 @@ Each line in the file is a JSON string corresponds to a single log item.
 Default: `fireworq.access`
 
 Specifies the value of `tag` field in a access log item.
+
+### <a name="env-dispatch-idle-conn-timeout">`FIREWORQ_DISPATCH_IDLE_CONN_TIMEOUT`, `--dispatch-idle-conn-timeout`</a>
+Default: `0`
+
+Specifies the maximum time of an idle (keep-alive) connections. If zero, an idle connections will not be closed. 
 
 ### <a name="env-dispatch-keep-alive">`FIREWORQ_DISPATCH_KEEP_ALIVE`, `--dispatch-keep-alive`</a>
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -64,7 +64,7 @@ Specifies whether a connection to a worker should be reused.  This overrides [th
 ### <a name="env-dispatch-max-conns-per-host">`FIREWORQ_DISPATCH_MAX_CONNS_PER_HOST`, `--dispatch-max-conns-per-host`</a>
 Default: `10`
 
-Specifies maximum idle connections to keep per-host. This value work only when [connections of the dispatcher are reused](#env-dispatch-keep-alive).
+Specifies maximum idle connections to keep per-host. This value works only when [connections of the dispatcher are reused](#env-dispatch-keep-alive).
 
 ### <a name="env-dispatch-user-agent">`FIREWORQ_DISPATCH_USER_AGENT`, `--dispatch-user-agent`</a>
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -16,6 +16,7 @@ applicable only to a [manual setup][section-manual-setup].
   - [`FIREWORQ_ACCESS_LOG`, `--access-log`](#env-access-log)
   - [`FIREWORQ_ACCESS_LOG_TAG`, `--access-log-tag`](#env-access-log-tag)
   - [`FIREWORQ_DISPATCH_KEEP_ALIVE`, `--dispatch-keep-alive`](#env-dispatch-keep-alive)
+  - [`FIREWORQ_DISPATCH_MAX_CONNS_PER_HOST`, `--dispatch-max-conns-per-host`](#env-dispatch-max-conns-per-host)
   - [`FIREWORQ_DISPATCH_USER_AGENT`, `--dispatch-user-agent`](#env-dispatch-user-agent)
   - [`FIREWORQ_ERROR_LOG`, `--error-log`](#env-error-log)
   - [`FIREWORQ_ERROR_LOG_LEVEL`, `--error-log-level`](#env-error-log-level)
@@ -53,6 +54,11 @@ Specifies the value of `tag` field in a access log item.
 ### <a name="env-dispatch-keep-alive">`FIREWORQ_DISPATCH_KEEP_ALIVE`, `--dispatch-keep-alive`</a>
 
 Specifies whether a connection to a worker should be reused.  This overrides [the default keep-alive setting](#env-keep-alive).
+
+### <a name="env-dispatch-max-conns-per-host">`FIREWORQ_DISPATCH_MAX_CONNS_PER_HOST`, `--dispatch-max-conns-per-host`</a>
+Default: `10`
+
+Specifies maximum idle connections to keep per-host.
 
 ### <a name="env-dispatch-user-agent">`FIREWORQ_DISPATCH_USER_AGENT`, `--dispatch-user-agent`</a>
 


### PR DESCRIPTION
In dozens of jobs situation, should enable keep-alive of the dispatcher. Because the dispatcher calls a lot of requests to the job's URL.

But `Transport.MaxIdleConnsPerHost` is zero. So it is used `http.DefaultMaxIdleConnsPerHost`.
As a result, the dispatcher has been consumed all local ports.

I added new flags for controlling an idle connection (a.k.a keep-alive).
`dispatch_max_conns_per_host` can control the `http.DefaultTransport.MaxIdleConnsPerHost`.
`dispatch_idle_conn_timeout` can control the `http.DefaultTransport.IdleConnTimeout`.
I think that these flags work well for controlling an idle connection.

### other problem

I believe that each queue has to have individual `Transport`. Because `Transport` caches connections.
But it is not fixed by this PR. I'm sure it's outside the scope of this patch.