### PR TITLE
Do not block pushing jobs during config reload

### DIFF
--- a/web/queue_test.go
+++ b/web/queue_test.go
@@ -2786,3 +2786,11 @@ func (q *mockRunningQueue) MaxWorkers() uint {
 func (q *mockRunningQueue) WorkerStats() *dispatcher.Stats {
 	return q.stats
 }
+
+func (q *mockRunningQueue) Deactivate() <-chan struct{} {
+	deactivated := make(chan struct{})
+	go func() {
+		deactivated <- struct{}{}
+	}()
+	return deactivated
+}


### PR DESCRIPTION
## Problem

When queues are reloaded (by changing a queue config), a new job is accepted by the HTTP server but blocked by `Service` until the whole reloading process completes.  Especially, stopping dispatchers will take long because they wait for workers to respond.

## How to solve

Accept new jobs during stopping dispatchers.  It is safe to push a new job even if no dispatcher is running.

## Change summary

- Separate the process to stop dispatchers from `destroyQueues` as `deactivateQueues`.
- Introduce a new mutex for pushing jobs which won't be locked by the deactivation.

