### PR TITLE
Introduce scopelint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,8 @@ lint: generate
 	for d in $$(${GO} list ./...); do \
 	  golint --set_exit_status "$$d" || exit $$? ; \
 	done
+	GO111MODULE=off ${GO} get github.com/kyoh86/scopelint
+	scopelint --set-exit-status --no-test ./...
 	for f in $$(${GO} list -f '{{$$p := .}}{{range $$f := .GoFiles}}{{$$p.Dir}}/{{$$f}} {{end}} {{range $$f := .TestGoFiles}}{{$$p.Dir}}/{{$$f}} {{end}}' ./... | xargs); do \
 	  [ $$(basename "$$f") = 'assets.go' ] && continue ; \
 	  test -z "$$(gofmt -d -s "$$f" | tee /dev/stderr)" || exit $$? ; \

--- a/service/service.go
+++ b/service/service.go
@@ -222,6 +222,7 @@ func (s *Service) startup() {
 		log.Panic().Msg(err.Error())
 	}
 	for _, q := range qs {
+		q := q
 		s.putJobQueue(&q)
 	}
 


### PR DESCRIPTION
This pull request introduces [scopelint](https://github.com/kyoh86/scopelint), which prevents from [a kind of common mistakes in Go](https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable). Also fixed one warning as suggested by the lint.