### PR TITLE
Add Dockerfile for production use

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+/.git/
+/.github/
+/dist/
+
+/junit_output.xml
+/profile.cov
+/coverage.html
+/coverage.xml
+status.tmp
+
+docker-compose
+/fireworq

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.14.4 as builder
+ENV APP_DIR /go/src/github.com/fireworq/fireworq
+
+WORKDIR ${APP_DIR}
+COPY . .
+RUN make release
+
+FROM alpine:3.12.0
+ENV APP_DIR /go/src/github.com/fireworq/fireworq
+
+COPY --from=builder ${APP_DIR}/fireworq /usr/local/bin/
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/fireworq"]

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ other variables.
 - [Full List of Configurations][page-configuration]
   - [Common Variables/Arguments][section-config-common]
   - [Variables/Arguments only Applicable to Manual Setup][section-config-manual-setup]
-  - [Variables only Applicable to a Docker-composed Instance][section-config-docker]
+  - [Variables only Applicable to a Docker-composed Instance][section-config-docker-compose]
 - [Make It Production-Ready][page-production-ready]
   - [Using a Release Build (Manual setup)][section-manual-setup]
   - [Preparing a Backup Instance][section-backup]
@@ -238,7 +238,7 @@ other variables.
 [page-configuration]: ./doc/config.md
 [section-config-common]: ./doc/config.md#config-common
 [section-config-manual-setup]: ./doc/config.md#config-manual-setup
-[section-config-docker]: ./doc/config.md#config-docker
+[section-config-docker-compose]: ./doc/config.md#config-docker
 [page-api]: ./doc/api.md
 [section-api-queue]: ./doc/api.md#api-queue
 [section-api-routing]: ./doc/api.md#api-routing

--- a/doc/config.md
+++ b/doc/config.md
@@ -37,7 +37,7 @@ applicable only to a [manual setup][section-manual-setup].
   - [`FIREWORQ_QUEUE_MYSQL_DSN`, `--queue-mysql-dsn`](#env-queue-mysql-dsn)
   - [`FIREWORQ_REPOSITORY_MYSQL_DSN`, `--repository-mysql-dsn`](#env-repository-mysql-dsn)
   - [`FIREWORQ_SHUTDOWN_TIMEOUT`, `--shutdown-timeout`](#env-shutdown-timeout)
-- [Variables only Applicable to a Docker-composed Instance][section-config-docker]
+- [Variables only Applicable to a Docker-composed Instance][section-config-docker-compose]
   - [`FIREWORQ_PORT`](#env-port)
 
 ## <a name="config-common">Common Variables/Arguments</a>
@@ -178,7 +178,7 @@ Default: `30`
 Specifies a timeout, in seconds, which the daemon waits on [gracefully shutting down or restarting][section-graceful-restart].
 
 
-## <a name="config-docker">Variables only Applicable to a Docker-composed Instance</a>
+## <a name="config-docker-compose">Variables only Applicable to a Docker-composed Instance</a>
 
 ### <a name="env-port">`FIREWORQ_PORT`</a>
 
@@ -188,7 +188,7 @@ Specifies the port number of a daemon.
 
 [section-config-common]: #config-common
 [section-config-manual-setup]: #config-manual-setup
-[section-config-docker]: #config-docker
+[section-config-docker-compose]: #config-docker-compose
 [section-manual-setup]: ./production.md#manual-setup
 [section-graceful-restart]: ./production.md#graceful-restart
 

--- a/script/gendoc/gendoc.go
+++ b/script/gendoc/gendoc.go
@@ -47,7 +47,7 @@ applicable only to a [manual setup][section-manual-setup].`)
 	fmt.Println(`- [Variables/Arguments only Applicable to Manual Setup][section-config-manual-setup]`)
 	categorized["manual"].printTableOfContents()
 
-	fmt.Println(`- [Variables only Applicable to a Docker-composed Instance][section-config-docker]
+	fmt.Println(`- [Variables only Applicable to a Docker-composed Instance][section-config-docker-compose]
   - [` + "`" + `FIREWORQ_PORT` + "`" + `](#env-port)`)
 
 	fmt.Println(`
@@ -59,7 +59,7 @@ applicable only to a [manual setup][section-manual-setup].`)
 	categorized["manual"].printDescriptions()
 
 	fmt.Println(`
-## <a name="config-docker">Variables only Applicable to a Docker-composed Instance</a>
+## <a name="config-docker-compose">Variables only Applicable to a Docker-composed Instance</a>
 
 ### <a name="env-port">` + "`" + `FIREWORQ_PORT` + "`" + `</a>
 
@@ -70,7 +70,7 @@ Specifies the port number of a daemon.`)
 	fmt.Print(`
 [section-config-common]: #config-common
 [section-config-manual-setup]: #config-manual-setup
-[section-config-docker]: #config-docker
+[section-config-docker-compose]: #config-docker-compose
 [section-manual-setup]: ./production.md#manual-setup
 [section-graceful-restart]: ./production.md#graceful-restart
 


### PR DESCRIPTION
I added Dockerfile for release build ready for production use. Current [docker setup](https://github.com/fireworq/fireworq/tree/master/script/docker) is not for production use and the [Dockerfile](https://github.com/fireworq/fireworq/blob/1070292ebc45512b71d7eeafaccc57e50165352f/script/docker/fireworq/Dockerfile) expects the shared volume from the [code container](https://github.com/fireworq/fireworq/blob/9821dfcc28d4cda5f52561678abadef04513548d/script/docker/code/Dockerfile) so it's not appropriate to use these files for building the production image. I introduced a new Dockerfile for building the release image with minimum requirements.