### PR TITLE
Fix leaving log files from tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ status.tmp
 
 *.exe
 *.test
+*.log
 
 assets.go
 mock_*.go

--- a/main_non_unix_test.go
+++ b/main_non_unix_test.go
@@ -4,3 +4,5 @@
 package main
 
 func initTestMain() {}
+
+func cleanTestMain() {}

--- a/main_test.go
+++ b/main_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestMain(m *testing.M) {
 	initTestMain()
+	defer cleanTestMain()
 
 	status, err := test.Run(m)
 	if err != nil {

--- a/main_unix_test.go
+++ b/main_unix_test.go
@@ -32,6 +32,11 @@ func initTestMain() {
 	})
 }
 
+func cleanTestMain() {
+	os.Remove(testAccessLog)
+	os.Remove(testErrorLog)
+}
+
 func TestInitLogging(t *testing.T) {
 	config.Locally("access_log", testAccessLog, func() {
 		config.Locally("error_log", testErrorLog, func() {


### PR DESCRIPTION
Currently `go test .` leaves `test-access.log` and `test-error.log`, which are not ignored by `.gitignore`. This pr fixes this problem.