### PR TITLE
Configure FIREWORQ_BIND in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,6 @@ FROM alpine:3.12.0
 ENV APP_DIR /go/src/github.com/fireworq/fireworq
 
 COPY --from=builder ${APP_DIR}/fireworq /usr/local/bin/
+ENV FIREWORQ_BIND 0.0.0.0:8080
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/fireworq"]


### PR DESCRIPTION
Without this binding configuration, we can't access from outside the container.