### PR TITLE
Update README to use Docker Hub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,24 @@ We appreciate your pull requests!
 
 ## Using docker
 
-The [Docker][] environment explained in [the first section][section-start] can also be used for developing.  Each time you run `script/docker/compose up`, a Fireworq instance with the latest code will come up.  Note that sometimes you need `script/docker/compose clean` for example when you add a new dependency.
+Run the following commands and you will get the whole system working
+all at once.  Make sure you have [Docker][] and [Docker Compose][]
+installed before running these commands.
+
+```
+$ git clone https://github.com/fireworq/fireworq
+$ cd fireworq
+$ script/docker/compose up
+```
+
+When Fireworq gets ready, it will listen on `localhost:8080` (on the
+host machine).  Specify `FIREWORQ_PORT` environment variable if you
+want Fireworq to listen on a different port.
+
+Each time you run `script/docker/compose up`, a Fireworq instance with
+the latest code will come up.  Note that sometimes you need
+`script/docker/compose clean` for example when you add a new
+dependency.
 
 To run automated tests, the following command does it for you.
 
@@ -13,7 +30,10 @@ To run automated tests, the following command does it for you.
 $ script/ci/test/docker-run
 ```
 
-This command always clean up all the docker images used for the tests.  If you are going to run the tests many times in your iteration, you should consider manual compilation and testing explained in the next section.
+This command always clean up all the docker images used for the tests.
+If you are going to run the tests many times in your iteration, you
+should consider manual compilation and testing explained in the next
+section.
 
 ## Manual compilation and testing
 
@@ -60,6 +80,7 @@ Now you can start developing with the following commands.
 [releases]: https://github.com/fireworq/fireworq/releases
 
 [Docker]: https://www.docker.com/
+[Docker Compose]: https://docs.docker.com/compose/
 [Golang]: https://golang.org/
 [MySQL]: https://www.mysql.com/
 [golint]: https://github.com/golang/lint

--- a/README.md
+++ b/README.md
@@ -162,9 +162,7 @@ other variables.
   Specifies the name of a default queue.  A job whose `category` is
   not defined via the [routing API][api-put-routing] will be delivered
   to this queue.  If no default queue name is specified, pushing a job
-  with an unknown category will fail for a
-  [manual setup][section-manual-setup].  A docker-composed instance
-  uses `default` as a default value.
+  with an unknown category will fail.
 
   If you already have a queue with the specified name in the job queue
   database, that one is used.  Or otherwise a new queue is created
@@ -189,9 +187,6 @@ other variables.
   - [Routing Management][section-api-routing]
   - [Job Management][section-api-job]
 - [Full List of Configurations][page-configuration]
-  - [Common Variables/Arguments][section-config-common]
-  - [Variables/Arguments only Applicable to Manual Setup][section-config-manual-setup]
-  - [Variables only Applicable to a Docker-composed Instance][section-config-docker-compose]
 - [Make It Production-Ready][page-production-ready]
   - [Using a Release Build (Manual setup)][section-manual-setup]
   - [Preparing a Backup Instance][section-backup]
@@ -214,9 +209,6 @@ other variables.
 [section-license]: #license
 
 [page-configuration]: ./doc/config.md
-[section-config-common]: ./doc/config.md#config-common
-[section-config-manual-setup]: ./doc/config.md#config-manual-setup
-[section-config-docker-compose]: ./doc/config.md#config-docker
 [page-api]: ./doc/api.md
 [section-api-queue]: ./doc/api.md#api-queue
 [section-api-routing]: ./doc/api.md#api-routing

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Fireworq][logo]
 =================
 
-[![Build Status](https://travis-ci.org/fireworq/fireworq.svg?branch=master)](https://travis-ci.org/fireworq/fireworq) [![Coverage Status](https://coveralls.io/repos/github/fireworq/fireworq/badge.svg?branch=master)](https://coveralls.io/github/fireworq/fireworq?branch=master)
+[![Build Status](https://travis-ci.org/fireworq/fireworq.svg?branch=master)](https://travis-ci.org/fireworq/fireworq) [![Coverage Status](https://coveralls.io/repos/github/fireworq/fireworq/badge.svg?branch=master)](https://coveralls.io/github/fireworq/fireworq?branch=master) [![Docker Hub](https://img.shields.io/badge/docker%20build-ready-blue)](https://hub.docker.com/r/fireworq/fireworq)
 
 Fireworq is a lightweight, high-performance job queue system with the
 following abilities.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Fireworq][logo]
 =================
 
-[![Build Status](https://travis-ci.org/fireworq/fireworq.svg?branch=master)](https://travis-ci.org/fireworq/fireworq) [![Coverage Status](https://coveralls.io/repos/github/fireworq/fireworq/badge.svg?branch=master)](https://coveralls.io/github/fireworq/fireworq?branch=master) [![Docker Hub](https://img.shields.io/badge/docker%20build-ready-blue)](https://hub.docker.com/r/fireworq/fireworq)
+[![Build Status](https://travis-ci.org/fireworq/fireworq.svg?branch=master)](https://travis-ci.org/fireworq/fireworq) [![Coverage Status](https://coveralls.io/repos/github/fireworq/fireworq/badge.svg?branch=master)](https://coveralls.io/github/fireworq/fireworq?branch=master) [![Docker Hub](https://img.shields.io/badge/docker%20build-ready-blue)](https://hub.docker.com/r/fireworq/fireworq) [![Latest version of on Docker Hub](https://images.microbadger.com/badges/version/fireworq/fireworq.svg)](https://microbadger.com/images/fireworq/fireworq)
 
 Fireworq is a lightweight, high-performance job queue system with the
 following abilities.

--- a/README.md
+++ b/README.md
@@ -59,35 +59,14 @@ all at once.  Make sure you have [Docker][] installed before running
 these commands.
 
 ```
-$ git clone https://github.com/fireworq/fireworq
-$ cd fireworq
-$ script/docker/compose up
-```
-
-When Fireworq gets ready, it will listen on `localhost:8080` (on the
-host machine).  Specify `FIREWORQ_PORT` environment variable if you
-want Fireworq to listen on a different port.
-
-```
-$ FIREWORQ_PORT=1234 script/docker/compose up
+$ docker run -p 8080:8080 fireworq/fireworq --driver=in-memory --queue-default=default
 ```
 
 Pressing `Ctrl+C` will gracefully shut it down.
 
-### Behind HTTP proxy
-
-If you are behind HTTP proxy, `script/docker/compose up` will fail.
-Add following configuration to `script/docker/docker-compose.yml`:
-
-```diff
- services:
-   fireworq:
-+    build:
-+      args:
-+        - http_proxy=http://.../
-+        - https_proxy=http://.../
-     environment:
-```
+Note that `in-memory` driver is not for production use.  It is
+intended to be used for just playing with Fireworq without a storage
+middleware.
 
 ## <a name="api">Using the API</a>
 
@@ -130,11 +109,10 @@ always ignored.
 
 Let's make the job asynchronous using Fireworq.  All you have to do is
 to make a `POST` request to Fireworq with a worker URL and a job
-payload.  If you have
-[a docker-composed Fireworq instance][section-start] and your docker
-host IP (from the container's point of view) is `172.17.0.1`, then
-requesting something like the following will enqueue exactly the same
-job in the previous example.
+payload.  If you have [a Fireworq docker instance][section-start] and
+your docker host IP (from the container's point of view) is
+`172.17.0.1`, then requesting something like the following will
+enqueue exactly the same job in the previous example.
 
 ```
 $ curl -XPOST -d '{"url":"http://172.17.0.1:3000/work","payload":{"id":12345}}' http://localhost:8080/job/foo

--- a/config/default.go
+++ b/config/default.go
@@ -1,7 +1,6 @@
 package config
 
 type configItem struct {
-	category     string
 	label        string
 	defaultValue string
 	description  string
@@ -20,7 +19,6 @@ var logLevelDescription = `The level is either a name or a numeric value.  The f
 
 var defaultConf = map[string]*configItem{
 	"bind": {
-		category:     "manual",
 		defaultValue: "127.0.0.1:8080",
 		label:        "<address>:<port>",
 		description: `
@@ -28,7 +26,6 @@ Specifies the address and the port number of a daemon in a form <code><var>addre
 `,
 	},
 	"pid": {
-		category:     "common",
 		defaultValue: "",
 		label:        "<file>",
 		description: `
@@ -36,7 +33,6 @@ Specifies a file where PID is written to.
 `,
 	},
 	"access_log": {
-		category:     "common",
 		defaultValue: "",
 		label:        "<file>",
 		description: `
@@ -46,7 +42,6 @@ Each line in the file is a JSON string corresponds to a single log item.
 `,
 	},
 	"access_log_tag": {
-		category:     "common",
 		defaultValue: "fireworq.access",
 		label:        "<tag>",
 		description: `
@@ -54,7 +49,6 @@ Specifies the value of ` + "`" + `tag` + "`" + ` field in a access log item.
 `,
 	},
 	"error_log": {
-		category:     "common",
 		defaultValue: "",
 		label:        "<file>",
 		description: `
@@ -64,7 +58,6 @@ If this value is specified, each line in the file is a JSON string corresponds t
 `,
 	},
 	"error_log_level": {
-		category:     "common",
 		defaultValue: "",
 		label:        "<level>",
 		description: `
@@ -73,7 +66,6 @@ If none of these values is specified, the level is determined by ` + "`" + `DEBU
 `,
 	},
 	"shutdown_timeout": {
-		category:     "manual",
 		defaultValue: "30",
 		label:        "<seconds>",
 		description: `
@@ -81,7 +73,6 @@ Specifies a timeout, in seconds, which the daemon waits on [gracefully shutting 
 `,
 	},
 	"keep_alive": {
-		category:     "common",
 		defaultValue: "false",
 		label:        "true|false",
 		description: `
@@ -89,7 +80,6 @@ Specifies whether connections should be reused.
 `,
 	},
 	"config_refresh_interval": {
-		category:     "manual",
 		defaultValue: "1000",
 		label:        "<milliseconds>",
 		description: `
@@ -97,7 +87,6 @@ Specifies an interval, in milliseconds, at which a Fireworq daemon checks if con
 `,
 	},
 	"driver": {
-		category:     "manual",
 		defaultValue: "mysql",
 		label:        "<driver>",
 		description: `
@@ -107,7 +96,6 @@ Note that ` + "`in-memory`" + ` driver is not for production use.  It is intende
 `,
 	},
 	"mysql_dsn": {
-		category:     "manual",
 		defaultValue: "tcp(localhost:3306)/fireworq",
 		label:        "<DSN>",
 		description: `
@@ -115,7 +103,6 @@ Specifies a data source name for the job queue and the repository database in a 
 `,
 	},
 	"repository_mysql_dsn": {
-		category:     "manual",
 		defaultValue: "",
 		label:        "<DSN>",
 		description: `
@@ -123,17 +110,15 @@ Specifies a data source name for the repository database in a form <code><var>us
 `,
 	},
 	"queue_default": {
-		category:     "common",
 		defaultValue: "",
 		label:        "<name>",
 		description: `
-Specifies the name of a default queue.  A job whose ` + "`" + `category` + "`" + ` is not defined via the [routing API][api-put-routing] will be delivered to this queue.  If no default queue name is specified, pushing a job with an unknown category will fail for a [manual setup][section-manual-setup].  A docker-composed instance uses ` + "`" + `default` + "`" + ` as a default value.
+Specifies the name of a default queue.  A job whose ` + "`" + `category` + "`" + ` is not defined via the [routing API][api-put-routing] will be delivered to this queue.  If no default queue name is specified, pushing a job with an unknown category will fail.
 
 If you already have a queue with the specified name in the job queue database, that one is used.  Or otherwise a new queue is created automatically.
 `,
 	},
 	"queue_default_polling_interval": {
-		category:     "common",
 		defaultValue: "200",
 		label:        "<milliseconds>",
 		description: `
@@ -141,7 +126,6 @@ Specifies the default interval, in milliseconds, at which Fireworq checks the ar
 `,
 	},
 	"queue_default_max_workers": {
-		category:     "common",
 		defaultValue: "20",
 		label:        "<number>",
 		description: `
@@ -149,7 +133,6 @@ Specifies the default maximum number of jobs that are processed simultaneously i
 `,
 	},
 	"queue_log": {
-		category:     "common",
 		defaultValue: "",
 		label:        "<file>",
 		description: `
@@ -159,7 +142,6 @@ Each line in the file is a JSON string corresponds to a single log item.
 `,
 	},
 	"queue_log_tag": {
-		category:     "common",
 		defaultValue: "fireworq.queue",
 		label:        "<tag>",
 		description: `
@@ -167,7 +149,6 @@ Specifies the value of ` + "`" + `tag` + "`" + ` field in a job queue log item J
 `,
 	},
 	"queue_log_level": {
-		category:     "common",
 		defaultValue: "",
 		label:        "<level>",
 		description: `
@@ -176,7 +157,6 @@ If none of these values is specified, the level is determined by ` + "`" + `DEBU
 `,
 	},
 	"queue_mysql_dsn": {
-		category:     "manual",
 		defaultValue: "",
 		label:        "<DSN>",
 		description: `
@@ -184,7 +164,6 @@ Specifies a data source name for the job queue database in a form <code><var>use
 `,
 	},
 	"dispatch_user_agent": {
-		category:     "common",
 		defaultValue: "",
 		label:        "<agent>",
 		description: `
@@ -192,14 +171,12 @@ Specifies the value of ` + "`" + `User-Agent` + "`" + ` header field used for an
 `,
 	},
 	"dispatch_keep_alive": {
-		category: "common",
-		label:    "true|false",
+		label: "true|false",
 		description: `
 Specifies whether a connection to a worker should be reused.  This overrides [the default keep-alive setting](#env-keep-alive).
 `,
 	},
 	"dispatch_max_conns_per_host": {
-		category:     "common",
 		defaultValue: "10",
 		label:        "<number>",
 		description: `
@@ -207,7 +184,6 @@ Specifies maximum idle connections to keep per-host. This value works only when 
 `,
 	},
 	"dispatch_idle_conn_timeout": {
-		category:     "common",
 		defaultValue: "0",
 		label:        "<seconds>",
 		description: `

--- a/config/descriptions.go
+++ b/config/descriptions.go
@@ -28,7 +28,6 @@ func Descriptions() []Item {
 
 // Item describes a configuration key and its default value.
 type Item struct {
-	Category     string
 	Name         string
 	DefaultValue string
 	Label        string
@@ -38,7 +37,6 @@ type Item struct {
 func (item *configItem) export(name string) Item {
 	return Item{
 		Name:         name,
-		Category:     item.category,
 		DefaultValue: item.defaultValue,
 		Label:        item.label,
 		Description:  item.description,

--- a/doc/config.md
+++ b/doc/config.md
@@ -4,43 +4,34 @@ Configuration
 =============
 
 You can configure Fireworq by providing environment variables on
-starting a daemon (for both docker-composed and manually-set-up
-instances) or by specifying command line arguments (for a manual
-setup).  Command line arguments precede the values of environment
-variables.
+starting a daemon or by specifying command line arguments.  Command
+line arguments precede the values of environment variables.
 
-The following variables/arguments are available.  Some of them are
-applicable only to a [manual setup][section-manual-setup].
+The following variables/arguments are available.
 
-- [Common Variables/Arguments][section-config-common]
-  - [`FIREWORQ_ACCESS_LOG`, `--access-log`](#env-access-log)
-  - [`FIREWORQ_ACCESS_LOG_TAG`, `--access-log-tag`](#env-access-log-tag)
-  - [`FIREWORQ_DISPATCH_IDLE_CONN_TIMEOUT`, `--dispatch-idle-conn-timeout`](#env-dispatch-idle-conn-timeout)
-  - [`FIREWORQ_DISPATCH_KEEP_ALIVE`, `--dispatch-keep-alive`](#env-dispatch-keep-alive)
-  - [`FIREWORQ_DISPATCH_MAX_CONNS_PER_HOST`, `--dispatch-max-conns-per-host`](#env-dispatch-max-conns-per-host)
-  - [`FIREWORQ_DISPATCH_USER_AGENT`, `--dispatch-user-agent`](#env-dispatch-user-agent)
-  - [`FIREWORQ_ERROR_LOG`, `--error-log`](#env-error-log)
-  - [`FIREWORQ_ERROR_LOG_LEVEL`, `--error-log-level`](#env-error-log-level)
-  - [`FIREWORQ_KEEP_ALIVE`, `--keep-alive`](#env-keep-alive)
-  - [`FIREWORQ_PID`, `--pid`](#env-pid)
-  - [`FIREWORQ_QUEUE_DEFAULT`, `--queue-default`](#env-queue-default)
-  - [`FIREWORQ_QUEUE_DEFAULT_MAX_WORKERS`, `--queue-default-max-workers`](#env-queue-default-max-workers)
-  - [`FIREWORQ_QUEUE_DEFAULT_POLLING_INTERVAL`, `--queue-default-polling-interval`](#env-queue-default-polling-interval)
-  - [`FIREWORQ_QUEUE_LOG`, `--queue-log`](#env-queue-log)
-  - [`FIREWORQ_QUEUE_LOG_LEVEL`, `--queue-log-level`](#env-queue-log-level)
-  - [`FIREWORQ_QUEUE_LOG_TAG`, `--queue-log-tag`](#env-queue-log-tag)
-- [Variables/Arguments only Applicable to Manual Setup][section-config-manual-setup]
-  - [`FIREWORQ_BIND`, `--bind`](#env-bind)
-  - [`FIREWORQ_CONFIG_REFRESH_INTERVAL`, `--config-refresh-interval`](#env-config-refresh-interval)
-  - [`FIREWORQ_DRIVER`, `--driver`](#env-driver)
-  - [`FIREWORQ_MYSQL_DSN`, `--mysql-dsn`](#env-mysql-dsn)
-  - [`FIREWORQ_QUEUE_MYSQL_DSN`, `--queue-mysql-dsn`](#env-queue-mysql-dsn)
-  - [`FIREWORQ_REPOSITORY_MYSQL_DSN`, `--repository-mysql-dsn`](#env-repository-mysql-dsn)
-  - [`FIREWORQ_SHUTDOWN_TIMEOUT`, `--shutdown-timeout`](#env-shutdown-timeout)
-- [Variables only Applicable to a Docker-composed Instance][section-config-docker-compose]
-  - [`FIREWORQ_PORT`](#env-port)
-
-## <a name="config-common">Common Variables/Arguments</a>
+- [`FIREWORQ_ACCESS_LOG`, `--access-log`](#env-access-log)
+- [`FIREWORQ_ACCESS_LOG_TAG`, `--access-log-tag`](#env-access-log-tag)
+- [`FIREWORQ_BIND`, `--bind`](#env-bind)
+- [`FIREWORQ_CONFIG_REFRESH_INTERVAL`, `--config-refresh-interval`](#env-config-refresh-interval)
+- [`FIREWORQ_DISPATCH_IDLE_CONN_TIMEOUT`, `--dispatch-idle-conn-timeout`](#env-dispatch-idle-conn-timeout)
+- [`FIREWORQ_DISPATCH_KEEP_ALIVE`, `--dispatch-keep-alive`](#env-dispatch-keep-alive)
+- [`FIREWORQ_DISPATCH_MAX_CONNS_PER_HOST`, `--dispatch-max-conns-per-host`](#env-dispatch-max-conns-per-host)
+- [`FIREWORQ_DISPATCH_USER_AGENT`, `--dispatch-user-agent`](#env-dispatch-user-agent)
+- [`FIREWORQ_DRIVER`, `--driver`](#env-driver)
+- [`FIREWORQ_ERROR_LOG`, `--error-log`](#env-error-log)
+- [`FIREWORQ_ERROR_LOG_LEVEL`, `--error-log-level`](#env-error-log-level)
+- [`FIREWORQ_KEEP_ALIVE`, `--keep-alive`](#env-keep-alive)
+- [`FIREWORQ_MYSQL_DSN`, `--mysql-dsn`](#env-mysql-dsn)
+- [`FIREWORQ_PID`, `--pid`](#env-pid)
+- [`FIREWORQ_QUEUE_DEFAULT`, `--queue-default`](#env-queue-default)
+- [`FIREWORQ_QUEUE_DEFAULT_MAX_WORKERS`, `--queue-default-max-workers`](#env-queue-default-max-workers)
+- [`FIREWORQ_QUEUE_DEFAULT_POLLING_INTERVAL`, `--queue-default-polling-interval`](#env-queue-default-polling-interval)
+- [`FIREWORQ_QUEUE_LOG`, `--queue-log`](#env-queue-log)
+- [`FIREWORQ_QUEUE_LOG_LEVEL`, `--queue-log-level`](#env-queue-log-level)
+- [`FIREWORQ_QUEUE_LOG_TAG`, `--queue-log-tag`](#env-queue-log-tag)
+- [`FIREWORQ_QUEUE_MYSQL_DSN`, `--queue-mysql-dsn`](#env-queue-mysql-dsn)
+- [`FIREWORQ_REPOSITORY_MYSQL_DSN`, `--repository-mysql-dsn`](#env-repository-mysql-dsn)
+- [`FIREWORQ_SHUTDOWN_TIMEOUT`, `--shutdown-timeout`](#env-shutdown-timeout)
 ### <a name="env-access-log">`FIREWORQ_ACCESS_LOG`, `--access-log`</a>
 
 Specifies a file where API access log is written to.  It defaults to standard output.
@@ -51,6 +42,16 @@ Each line in the file is a JSON string corresponds to a single log item.
 Default: `fireworq.access`
 
 Specifies the value of `tag` field in a access log item.
+
+### <a name="env-bind">`FIREWORQ_BIND`, `--bind`</a>
+Default: `127.0.0.1:8080`
+
+Specifies the address and the port number of a daemon in a form <code><var>address</var>:<var>port</var></code>.
+
+### <a name="env-config-refresh-interval">`FIREWORQ_CONFIG_REFRESH_INTERVAL`, `--config-refresh-interval`</a>
+Default: `1000`
+
+Specifies an interval, in milliseconds, at which a Fireworq daemon checks if configurations (such as queue definitions or routings) are changed by other daemons.
 
 ### <a name="env-dispatch-idle-conn-timeout">`FIREWORQ_DISPATCH_IDLE_CONN_TIMEOUT`, `--dispatch-idle-conn-timeout`</a>
 Default: `0`
@@ -69,6 +70,13 @@ Specifies maximum idle connections to keep per-host. This value works only when 
 ### <a name="env-dispatch-user-agent">`FIREWORQ_DISPATCH_USER_AGENT`, `--dispatch-user-agent`</a>
 
 Specifies the value of `User-Agent` header field used for an HTTP request to a worker.  The default value is <code>Fireworq/<var>version</var></code>.
+
+### <a name="env-driver">`FIREWORQ_DRIVER`, `--driver`</a>
+Default: `mysql`
+
+Specifies a driver for job queues and repositories.  The available values are `mysql` and `in-memory`.
+
+Note that `in-memory` driver is not for production use.  It is intended to be used for just playing with Fireworq without a storage middleware or to show the upper bound of performance in a benchmark.
 
 ### <a name="env-error-log">`FIREWORQ_ERROR_LOG`, `--error-log`</a>
 
@@ -95,13 +103,18 @@ Default: `false`
 
 Specifies whether connections should be reused.
 
+### <a name="env-mysql-dsn">`FIREWORQ_MYSQL_DSN`, `--mysql-dsn`</a>
+Default: `tcp(localhost:3306)/fireworq`
+
+Specifies a data source name for the job queue and the repository database in a form <code><var>user</var>:<var>password</var>@tcp(<var>mysql_host</var>:<var>mysql_port</var>)/<var>database</var>?<var>options</var></code>.  This is in effect only when [the driver](#env-driver) is `mysql` and is mandatory for that case.
+
 ### <a name="env-pid">`FIREWORQ_PID`, `--pid`</a>
 
 Specifies a file where PID is written to.
 
 ### <a name="env-queue-default">`FIREWORQ_QUEUE_DEFAULT`, `--queue-default`</a>
 
-Specifies the name of a default queue.  A job whose `category` is not defined via the [routing API][api-put-routing] will be delivered to this queue.  If no default queue name is specified, pushing a job with an unknown category will fail for a [manual setup][section-manual-setup].  A docker-composed instance uses `default` as a default value.
+Specifies the name of a default queue.  A job whose `category` is not defined via the [routing API][api-put-routing] will be delivered to this queue.  If no default queue name is specified, pushing a job with an unknown category will fail.
 
 If you already have a queue with the specified name in the job queue database, that one is used.  Or otherwise a new queue is created automatically.
 
@@ -140,30 +153,6 @@ Default: `fireworq.queue`
 
 Specifies the value of `tag` field in a job queue log item JSON.
 
-
-## <a name="config-manual-setup">Variables/Arguments only Applicable to Manual Setup</a>
-### <a name="env-bind">`FIREWORQ_BIND`, `--bind`</a>
-Default: `127.0.0.1:8080`
-
-Specifies the address and the port number of a daemon in a form <code><var>address</var>:<var>port</var></code>.
-
-### <a name="env-config-refresh-interval">`FIREWORQ_CONFIG_REFRESH_INTERVAL`, `--config-refresh-interval`</a>
-Default: `1000`
-
-Specifies an interval, in milliseconds, at which a Fireworq daemon checks if configurations (such as queue definitions or routings) are changed by other daemons.
-
-### <a name="env-driver">`FIREWORQ_DRIVER`, `--driver`</a>
-Default: `mysql`
-
-Specifies a driver for job queues and repositories.  The available values are `mysql` and `in-memory`.
-
-Note that `in-memory` driver is not for production use.  It is intended to be used for just playing with Fireworq without a storage middleware or to show the upper bound of performance in a benchmark.
-
-### <a name="env-mysql-dsn">`FIREWORQ_MYSQL_DSN`, `--mysql-dsn`</a>
-Default: `tcp(localhost:3306)/fireworq`
-
-Specifies a data source name for the job queue and the repository database in a form <code><var>user</var>:<var>password</var>@tcp(<var>mysql_host</var>:<var>mysql_port</var>)/<var>database</var>?<var>options</var></code>.  This is in effect only when [the driver](#env-driver) is `mysql` and is mandatory for that case.
-
 ### <a name="env-queue-mysql-dsn">`FIREWORQ_QUEUE_MYSQL_DSN`, `--queue-mysql-dsn`</a>
 
 Specifies a data source name for the job queue database in a form <code><var>user</var>:<var>password</var>@tcp(<var>mysql_host</var>:<var>mysql_port</var>)/<var>database</var>?<var>options</var></code>.  This is in effect only when the [driver](#env-driver) is `mysql` and overrides [the default DSN](#env-mysql-dsn).  This should be used when you want to specify a DSN differs from [the repository DSN](#env-repository-mysql-dsn).
@@ -178,17 +167,6 @@ Default: `30`
 Specifies a timeout, in seconds, which the daemon waits on [gracefully shutting down or restarting][section-graceful-restart].
 
 
-## <a name="config-docker-compose">Variables only Applicable to a Docker-composed Instance</a>
-
-### <a name="env-port">`FIREWORQ_PORT`</a>
-
-Default: `8080`
-
-Specifies the port number of a daemon.
-
-[section-config-common]: #config-common
-[section-config-manual-setup]: #config-manual-setup
-[section-config-docker-compose]: #config-docker-compose
 [section-manual-setup]: ./production.md#manual-setup
 [section-graceful-restart]: ./production.md#graceful-restart
 

--- a/script/gendoc/gendoc.go
+++ b/script/gendoc/gendoc.go
@@ -26,51 +26,22 @@ Configuration
 =============
 
 You can configure Fireworq by providing environment variables on
-starting a daemon (for both docker-composed and manually-set-up
-instances) or by specifying command line arguments (for a manual
-setup).  Command line arguments precede the values of environment
-variables.
+starting a daemon or by specifying command line arguments.  Command
+line arguments precede the values of environment variables.
 
-The following variables/arguments are available.  Some of them are
-applicable only to a [manual setup][section-manual-setup].`)
+The following variables/arguments are available.`)
 	fmt.Println("")
 
-	categorized := make(map[string]configItems)
+	items := make(configItems, 0)
 	for _, d := range config.Descriptions() {
 		item := &configItem{d}
-		categorized[item.Category] = append(categorized[item.Category], item)
+		items = append(items, item)
 	}
 
-	fmt.Println(`- [Common Variables/Arguments][section-config-common]`)
-	categorized["common"].printTableOfContents()
-
-	fmt.Println(`- [Variables/Arguments only Applicable to Manual Setup][section-config-manual-setup]`)
-	categorized["manual"].printTableOfContents()
-
-	fmt.Println(`- [Variables only Applicable to a Docker-composed Instance][section-config-docker-compose]
-  - [` + "`" + `FIREWORQ_PORT` + "`" + `](#env-port)`)
-
-	fmt.Println(`
-## <a name="config-common">Common Variables/Arguments</a>`)
-	categorized["common"].printDescriptions()
-
-	fmt.Println(`
-## <a name="config-manual-setup">Variables/Arguments only Applicable to Manual Setup</a>`)
-	categorized["manual"].printDescriptions()
-
-	fmt.Println(`
-## <a name="config-docker-compose">Variables only Applicable to a Docker-composed Instance</a>
-
-### <a name="env-port">` + "`" + `FIREWORQ_PORT` + "`" + `</a>
-
-Default: ` + "`" + `8080` + "`" + `
-
-Specifies the port number of a daemon.`)
+	items.printTableOfContents()
+	items.printDescriptions()
 
 	fmt.Print(`
-[section-config-common]: #config-common
-[section-config-manual-setup]: #config-manual-setup
-[section-config-docker-compose]: #config-docker-compose
 [section-manual-setup]: ./production.md#manual-setup
 [section-graceful-restart]: ./production.md#graceful-restart
 
@@ -83,7 +54,7 @@ type configItems []*configItem
 
 func (items configItems) printTableOfContents() {
 	for _, item := range items {
-		fmt.Println("  - " + item.Link())
+		fmt.Println("- " + item.Link())
 	}
 }
 


### PR DESCRIPTION
## In this P-R

- Recommend `docker run`ning a container from Docker Hub image in the first-step instruction
- Stop advertising docker-composed setup
  - This way is left only for developers

## Not in this P-R

- Container setup (non-manual setup) guide for production use
  - We will describe this someday