### PR TITLE
Add missing required permission to docs

### DIFF
--- a/doc/production.md
+++ b/doc/production.md
@@ -31,7 +31,7 @@ Before running Fireworq, make sure that you have
    and,
 1. some DB user <code><var>user</var></code> with some password
    <code><var>password</var></code>, who is granted `CREATE`,
-   `INSERT`, `DELETE` and `SELECT` rights on
+   `INSERT`, `DELETE`, `UPDATE` and `SELECT` rights on
    <code><var>database</var></code>.
 
 Then the following commands run Fireworq with the prepared MySQL database.


### PR DESCRIPTION
Add `UPDATE` to the docs for required MySQL user permissions.

Following the instructions as written I was receiving this error:

```log
5:21PM INF PID: 34
5:21PM INF Starting a job dispatcher...
5:21PM INF Select mysql as a driver for repositories
5:21PM INF Connecting database user:pass@tcp(queue-db:3306)/queue ...
5:21PM DBG wait_timeout: 28800
5:21PM PNC Cannot create default job queue: blast-jobs
panic: Cannot create default job queue: blast-jobs

goroutine 1 [running]:
github.com/rs/zerolog.(*Logger).Panic.func1(0xc00019a1b0, 0x2b)
        /go/pkg/mod/github.com/rs/zerolog@v1.19.0/log.go:342 +0x4f
github.com/rs/zerolog.(*Event).msg(0xc0001a8480, 0xc00019a1b0, 0x2b)
        /go/pkg/mod/github.com/rs/zerolog@v1.19.0/event.go:147 +0x2f6
github.com/rs/zerolog.(*Event).Msgf(0xc0001a8480, 0x8de37d, 0x23, 0xc0002d5d58, 0x1, 0x1)
        /go/pkg/mod/github.com/rs/zerolog@v1.19.0/event.go:127 +0x83
github.com/fireworq/fireworq/service.(*Service).startup(0xc0001b0690)
        /go/src/github.com/fireworq/fireworq/service/service.go:233 +0x2ae
github.com/fireworq/fireworq/service.NewService(0xc0001ac500, 0x0)
        /go/src/github.com/fireworq/fireworq/service/service.go:59 +0x453
main.startServer(0x7f29d8c861a0, 0xc0001902d0)
        /go/src/github.com/fireworq/fireworq/main.go:205 +0x61
main.main()
        /go/src/github.com/fireworq/fireworq/main.go:61 +0x1e9
```

After running with a debugger (breakpoint @ repository/mysql/queue.go:29) it
turns out the root error was actually:

```log
Error 1142: UPDATE command denied to user 'queue'@'192.168.208.1' for table 'queue'
```

After updating the user permissions in MySQL, the error no longer occurs.