### PR TITLE
Fix User-Agent fallback.

### DIFF
--- a/dispatcher/worker/http.go
+++ b/dispatcher/worker/http.go
@@ -92,7 +92,7 @@ func (worker *HTTPWorker) Work(job jobqueue.Job) *jobqueue.Result {
 	if userAgent == "" {
 		userAgent = defaultUserAgent
 	}
-	req.Header.Add("User-Agent", worker.UserAgent)
+	req.Header.Add("User-Agent", userAgent)
 
 	resp, err := client.Do(req)
 


### PR DESCRIPTION
In the current code the variable `userAgent` is assigned but unused. The indented behavior seems to use `defaultUserAgent` if `worker.UserAgent` is empty. Found by [ineffassign](https://github.com/gordonklaus/ineffassign).