### PR TITLE
Fix git_tag_name on release flow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set variables for Docker image
         id: variables
         run: |
-          git_tag_name="${{ github.event.release.tag_name }}"
+          git_tag_name="${GITHUB_REF#refs/tags/}"
           git_tag_name="${git_tag_name#v}"
           echo "::set-output name=release_tag_patch::${git_tag_name}"
           echo "::set-output name=release_tag_minor::${git_tag_name%.*}"


### PR DESCRIPTION
Since the action trigger is not `release`, we cannot use `github.event.release.tag_name`. We use `push: tags` trigger so we can use `$GITHUB_REF` ([ref]).

[ref]: https://github.community/t/how-to-get-just-the-tag-name/16241/9