### PR TITLE
Setup Go for gcov2lcov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,10 @@ jobs:
       uses: actions/checkout@v2
     - name: Test
       run: script/ci/test/docker-run
+    - name: Setup Go for gcov2lcov
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.x
     - name: Convert coverage to lcov
       uses: jandelgado/gcov2lcov-action@v1.0.8
       with:


### PR DESCRIPTION
We're experiencing CI failure on switching to `ubuntu-20.04` ([ref](https://github.com/fireworq/fireworq/runs/2092444701)). The [gcov2lcov](https://github.com/jandelgado/gcov2lcov) command depends on `go/build` package and thus on Go source code tree (GOROOT). We're seeing `go: cannot find GOROOT directory: /opt/hostedtoolcache/go/1.13.15/x64` error because [jandelgado@v1.0.4](https://github.com/jandelgado/gcov2lcov/releases/tag/v1.0.4) is built by Go 1.13.15 (despite the release notes says 1.15), and [ubuntu-20.04](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#go) does not have 1.13.15 installed while [ubuntu-18.04](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md#go) does. So implicit searching of go root (based on the Go used for building the executable) fails on ubuntu-20.04. Setting `$GOROOT` explicitly, or using setup-go fixes the problem.