### PR TITLE
Sort the queue list for in-memory repository

### DIFF
--- a/repository/inmemory/queue.go
+++ b/repository/inmemory/queue.go
@@ -2,6 +2,7 @@ package inmemory
 
 import (
 	"errors"
+	"sort"
 	"sync"
 
 	"github.com/fireworq/fireworq/model"
@@ -40,6 +41,10 @@ func (r *queueRepository) FindAll() ([]model.Queue, error) {
 	for _, q := range qs.m {
 		queues = append(queues, q)
 	}
+
+	sort.Slice(queues, func(i, j int) bool {
+		return queues[i].Name < queues[j].Name
+	})
 
 	return queues, nil
 }


### PR DESCRIPTION
This PR sorts the queue list of `FindAll()` for in-memory repository. There is already tests for the name ordering, which randomly fail.
https://github.com/fireworq/fireworq/blob/1cdc8d3beff22e09867abbcd03eb86ddef5996da/repository/factory/repository_test.go#L119-L134