### PR TITLE
Configure --exit-code-from for deriving exit code from test script

### DIFF
--- a/script/ci/test/docker-run
+++ b/script/ci/test/docker-run
@@ -14,7 +14,7 @@ DOCKER_COMPOSE="$DOCKER_COMPOSE -p $DOCKER_PROJECT_NAME"
 
 $DOCKER_COMPOSE build --force-rm || exit 1
 trap "" INT TERM
-$DOCKER_COMPOSE up --abort-on-container-exit
+$DOCKER_COMPOSE up --exit-code-from fireworq
 status=$?
 
 $DOCKER_COMPOSE down -v


### PR DESCRIPTION
This fixes potential pitfalls that CI succeeds on tests failure.