### PR TITLE
Add validation for max burst size

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -175,7 +175,7 @@ HTTP/1.1 200 OK
 |`polling_interval`         |An interval, in milliseconds, at which Fireworq checks the arrival of new jobs in this queue.|optional, defaults to [`FIREWORQ_QUEUE_DEFAULT_POLLING_INTERVAL`][env-queue-default-polling-interval]|
 |`max_workers`              |The maximum number of jobs that are processed simultaneously for this queue.|optional, defaults to [`FIREWORQ_QUEUE_DEFAULT_MAX_WORKERS`][env-queue-default-max-workers]|
 |`max_dispatches_per_second`|The maximum floating-point number of dispatches allowed to be processed within a second for this queue.|optional, defaults to no throttling. When throttling is configured, `polling_interval` is fixed to `100` regardless of the default interval|
-|`max_burst_size`           |The maximum number of burst size of throttling configuration for this queue.|optional, cannot be set without `max_dispatches_per_second`|
+|`max_burst_size`           |The maximum number of burst size of throttling configuration for this queue.|Must be set with `max_dispatches_per_second`, cannot be set without `max_dispatches_per_second`|
 
 |Response code            |Meaning                              |
 |:------------------------|:------------------------------------|

--- a/doc/api.md
+++ b/doc/api.md
@@ -175,7 +175,7 @@ HTTP/1.1 200 OK
 |`polling_interval`         |An interval, in milliseconds, at which Fireworq checks the arrival of new jobs in this queue.|optional, defaults to [`FIREWORQ_QUEUE_DEFAULT_POLLING_INTERVAL`][env-queue-default-polling-interval]|
 |`max_workers`              |The maximum number of jobs that are processed simultaneously for this queue.|optional, defaults to [`FIREWORQ_QUEUE_DEFAULT_MAX_WORKERS`][env-queue-default-max-workers]|
 |`max_dispatches_per_second`|The maximum floating-point number of dispatches allowed to be processed within a second for this queue.|optional, defaults to no throttling. When throttling is configured, `polling_interval` is fixed to `100` regardless of the default interval|
-|`max_burst_size`           |The maximum number of burst size of throttling configuration for this queue.|Must be set with `max_dispatches_per_second`, cannot be set without `max_dispatches_per_second`|
+|`max_burst_size`           |The maximum number of burst size of throttling configuration for this queue.|optional, configured with `max_dispatches_per_second`|
 
 |Response code            |Meaning                              |
 |:------------------------|:------------------------------------|

--- a/service/service.go
+++ b/service/service.go
@@ -149,6 +149,9 @@ const throttleQueuePollingInterval = 100
 func (s *Service) addJobQueue(q *model.Queue) error {
 	switch {
 	case q.MaxDispatchesPerSecond > 0.0:
+		if q.MaxBurstSize == 0 {
+			return errors.New("Cannot configure MaxDispatchesPerSecond without MaxBurstSize")
+		}
 		q.PollingInterval = throttleQueuePollingInterval
 	case q.MaxDispatchesPerSecond < 0.0:
 		return errors.New("MaxDispatchesPerSecond should be non-negative")

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -161,6 +161,17 @@ func TestAddJobQueue(t *testing.T) {
 			t.Error("AddJobQueue should fail with MaxBurstSize but without MaxDispatchesPerSecond")
 		}
 	}()
+
+	func() {
+		q := &model.Queue{
+			Name:                   queueName,
+			MaxDispatchesPerSecond: 1.0,
+		}
+		err := svc.AddJobQueue(q)
+		if err == nil {
+			t.Error("AddJobQueue should fail with MaxDispatchesPerSecond but without MaxBurstSize")
+		}
+	}()
 }
 
 func TestDeleteJobQueue(t *testing.T) {


### PR DESCRIPTION
This p-r supplements #141. Throttled queue with 0 burst size makes no sense, because it never allows any events.